### PR TITLE
Adding a paramater for removing .repository folder too

### DIFF
--- a/src/main/resources/hudson/plugins/perforce/PerforceSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/perforce/PerforceSCM/config.jelly
@@ -43,6 +43,10 @@
       <f:entry title="Clean Workspace Before Each Build" help="/plugin/perforce/help/wipeBeforeBuild.html">
         <f:checkbox field="wipeBeforeBuild" default="false" value="False"/>
       </f:entry>
+      
+      <f:entry title="Clean .repository Before Build" help="/plugin/perforce/help/wipeRepoBeforeBuild.html">
+        <f:checkbox field="wipeRepoBeforeBuild" default="false" value="False"/>
+      </f:entry>
 
       <f:entry title="View" help="/plugin/perforce/help/projectPath.html">
         <f:textarea field="projectPath"/>

--- a/src/main/webapp/help/wipeRepoBeforeBuild.html
+++ b/src/main/webapp/help/wipeRepoBeforeBuild.html
@@ -1,0 +1,15 @@
+<div>
+  <p>
+    <b>Clean .repository before build</b>: This option will cause the plugin to delete all files in the workspace including the .repository (relevant to Maven builds only).<br>
+    As of perforce-plugin 1.1.1 .repository is skipped<br>
+    If you wish to remain the default Cleanup behaviour and clean the entire workspace use this option.<br>
+    This option will also cause the plugin to perform a force sync to retrieve clean files from the perforce server.<br>
+  </p>
+  <p><b>Please note</b>:
+  <ul>
+      <ol>This option will only be set if "Clean Workspace Before Build" above is available.</ol>
+      <ol>This option can also be triggered by creating a Boolean parameter on the build called "P4CLEANREPOINWORKSPACE"<br>
+          Considering the "P4CLEANWORKSPACE" is also instantiated.</ol>
+  </ul>
+  </p>
+</div>

--- a/src/test/java/hudson/plugins/perforce/PerforceSCMTest.java
+++ b/src/test/java/hudson/plugins/perforce/PerforceSCMTest.java
@@ -22,7 +22,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         PerforceSCM scm = new PerforceSCM(
         		"user", "pass", "client", "port", "path", "", "exe", "sysRoot",
         		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, false,
-                        false, true, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file");
+                        false, true, false, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file");
         project.setScm(scm);
 
         // config roundtrip
@@ -43,7 +43,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         PerforceSCM scm = new PerforceSCM(
         		"user", password, "client", "port", "path", "", "exe", "sysRoot",
         		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, false,
-                        false, true, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file");
+                        false, true, false, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file");
         project.setScm(scm);
 
         // config roundtrip
@@ -67,7 +67,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         PerforceSCM scm = new PerforceSCM(
         		"user", password, "client", "port", "path", "", "exe", "sysRoot",
         		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, false,
-                        false, true, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file");
+                        false, true, false, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file");
 
         project.setScm(scm);
         
@@ -81,7 +81,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         PerforceSCM scm = new PerforceSCM(
         		"user", password, "client", "port", "path", "", "exe", "sysRoot",
         		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, false,
-                        false, true, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file");
+                        false, true, false, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file");
         project.setScm(scm);
 
         // config roundtrip


### PR DESCRIPTION
As I commented on http://issues.jenkins-ci.org/browse/JENKINS-7182 it seems as if we are missing functionality if one would want to force a clean .m2 upon clean builds, thus added a parameter + option in the UI to force the .repository to be erased too.

I have tested this locally with a maven build and it performs as expected.

Please add this to the next release.
