### PR TITLE
Resolve issue with email-ext-plugin+perforce-plugin

### DIFF
--- a/src/main/java/hudson/plugins/perforce/PerforceChangeLogEntry.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceChangeLogEntry.java
@@ -49,7 +49,14 @@ public class PerforceChangeLogEntry extends ChangeLogSet.Entry {
         return author;
     }
 
-    @Override
+    public String getUser() {
+        return getAuthor().getDisplayName();
+    }
+
+    public Collection<Changelist.FileEntry> getAffectedFiles() {
+        return change.getFiles();
+    }
+
     @Exported
     public Collection<String> getAffectedPaths() {
         List<String> paths = new ArrayList<String>(change.getFiles().size());
@@ -74,6 +81,13 @@ public class PerforceChangeLogEntry extends ChangeLogSet.Entry {
     public String getChangeTime() {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         return sdf.format(getChange().getDate());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getCurrentRevision() {
+        return getChangeNumber();
     }
 
     /**

--- a/src/main/java/hudson/plugins/perforce/PerforceChangeLogSet.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceChangeLogSet.java
@@ -7,6 +7,7 @@ import hudson.scm.ChangeLogSet;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.Iterator;
@@ -43,6 +44,10 @@ public class PerforceChangeLogSet extends ChangeLogSet<PerforceChangeLogEntry> {
     @Override
     public boolean isEmptySet() {
         return history.size() == 0;
+    }
+
+    public Collection<PerforceChangeLogEntry> getLogs() {
+        return history;
     }
 
     /*


### PR DESCRIPTION
Add ability to display changes of revision in email notification. Make perforce plugin compatible with the latest hudson-core and email-ext-plugin.
Notes:
1. This changes were made in order to unify ChangeSet interface for VCS plugins.
2. Changes are also related to http://issues.hudson-ci.org/browse/HUDSON-8852
