### PR TITLE
Add "Let Jenkins Create Workspace" checkbox

### DIFF
--- a/src/main/java/hudson/plugins/perforce/PerforceSCM.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceSCM.java
@@ -141,6 +141,10 @@ public class PerforceSCM extends SCM {
     @Deprecated
     boolean useOldClientName = false;
     /**
+     * If true, we will create the workspace view within the plugin.  If false, we will not.
+     */
+    boolean createWorkspace = true;
+    /**
      * If true, we will manage the workspace view within the plugin.  If false, we will leave the
      * view alone.
      */
@@ -258,6 +262,7 @@ public class PerforceSCM extends SCM {
             boolean forceSync,
             boolean dontUpdateServer,
             boolean alwaysForceSync,
+            boolean createWorkspace,
             boolean updateView,
             boolean disableAutoSync,
             boolean disableSyncOnly,
@@ -341,6 +346,7 @@ public class PerforceSCM extends SCM {
         this.browser = browser;
         this.wipeBeforeBuild = wipeBeforeBuild;
         this.wipeRepoBeforeBuild = wipeRepoBeforeBuild;
+        this.createWorkspace = createWorkspace;
         this.updateView = updateView;
         this.dontUpdateClient = dontUpdateClient;
         this.slaveClientNameFormat = slaveClientNameFormat;
@@ -1226,7 +1232,7 @@ public class PerforceSCM extends SCM {
 
         // If the client workspace doesn't exist, and we're not managing the clients,
         // Then terminate the build with an error
-        if(!updateView && creatingNewWorkspace){
+        if(!createWorkspace && creatingNewWorkspace){
             log.println("*** Perforce client workspace '" + p4Client +"' doesn't exist.");
             log.println("*** Please create it, or allow Jenkins to manage clients on it's own.");
             log.println("*** If the client name mentioned above is not what you expected, ");
@@ -2172,6 +2178,20 @@ public class PerforceSCM extends SCM {
      */
     public void setProjectOptions(String projectOptions) {
         this.projectOptions = projectOptions;
+    }
+
+    /**
+     * @param createWorkspace    True to let the plugin create the workspace, false to let the user manage it
+     */
+    public void setCreateWorkspace(boolean val) {
+        this.createWorkspace = val;
+    }
+
+    /**
+     * @return  True if the plugin manages the view, false if the user does.
+     */
+    public boolean isCreateWorkspace() {
+        return createWorkspace;
     }
 
     /**

--- a/src/main/resources/hudson/plugins/perforce/PerforceSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/perforce/PerforceSCM/config.jelly
@@ -42,6 +42,9 @@
         <f:textbox field="p4Client" id="p4Client"
                 checkUrl="'${rootURL}/scm/PerforceSCM/validateP4Client?port='+escape(this.form.elements['p4Port'].value)+'&amp;exe='+escape(this.form.elements['p4Exe'].value)+'&amp;user='+escape(this.form.elements['p4User'].value)+'&amp;pass='+escape(this.form.elements['p4Passwd'].value)+'&amp;client='+escape(this.form.elements['p4Client'].value)"/>
       </f:entry>
+      <f:entry title="Let ${descriptor['appName']} Create Workspace" help="/plugin/perforce/help/createWorkspace.html">
+        <f:checkbox field="createWorkspace" default="true" value="True"/>
+      </f:entry>
       <f:entry title="Let ${descriptor['appName']} Manage Workspace View" help="/plugin/perforce/help/updateView.html">
         <f:checkbox field="updateView" default="true" value="True"/>
       </f:entry>

--- a/src/main/webapp/help/createWorkspace.html
+++ b/src/main/webapp/help/createWorkspace.html
@@ -1,0 +1,10 @@
+<div>
+  <p>
+    <b>Let Hudson/Jenkins Create Workspace</b>: For most cases, leave this checked.  Hudson/Jenkins will create
+    the workspace from the project's settings provided below.
+  </p>
+  <p>
+    If unchecked, you must create the workspace yourself.  If you have a separate tool for managing your workspace
+    view, you may want to check this and uncheck letting Hudson/Jenkins manage your view.
+  </p>
+</div>

--- a/src/test/java/hudson/plugins/perforce/PerforceSCMTest.java
+++ b/src/test/java/hudson/plugins/perforce/PerforceSCMTest.java
@@ -21,7 +21,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         P4Web browser = new P4Web(new URL("http://localhost/"));
         PerforceSCM scm = new PerforceSCM(
         		"user", "pass", "client", "port", "", "exe", "sysRoot",
-        		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, true, false,
+        		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, true, true, false,
                         false, true, false, false, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file");
         scm.setProjectPath("path");
         project.setScm(scm);
@@ -31,7 +31,7 @@ public class PerforceSCMTest extends HudsonTestCase {
 
         // verify that the data is intact
         assertEqualBeans(scm, project.getScm(),
-                "p4User,p4Client,p4Port,p4Label,projectPath,p4Exe,p4SysRoot,p4SysDrive,forceSync,alwaysForceSync,dontUpdateClient,updateView,slaveClientNameFormat,lineEndValue,firstChange,p4Counter,updateCounterValue,exposeP4Passwd,useViewMaskForPolling,viewMask,useViewMaskForSyncing,p4Charset,p4CommandCharset,p4Stream,useStreamDepot");
+                "p4User,p4Client,p4Port,p4Label,projectPath,p4Exe,p4SysRoot,p4SysDrive,forceSync,alwaysForceSync,dontUpdateClient,createWorkspace,updateView,slaveClientNameFormat,lineEndValue,firstChange,p4Counter,updateCounterValue,exposeP4Passwd,useViewMaskForPolling,viewMask,useViewMaskForSyncing,p4Charset,p4CommandCharset,p4Stream,useStreamDepot");
         assertEquals("exclude_user", scm.getExcludedUsers());
         assertEquals("exclude_file", scm.getExcludedFiles());
         //assertEqualBeans(scm.getBrowser(),p.getScm().getBrowser(),"URL");
@@ -42,7 +42,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         P4Web browser = new P4Web(new URL("http://localhost/"));
         PerforceSCM scm = new PerforceSCM(
         		"user", "pass", "client", "port", "", "exe", "sysRoot",
-        		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, true, false,
+        		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, true, true, false,
                         false, true, false, false, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file");
         scm.setP4Stream("stream");
         scm.setUseStreamDepot(true);
@@ -53,7 +53,7 @@ public class PerforceSCMTest extends HudsonTestCase {
 
         // verify that the data is intact
         assertEqualBeans(scm, project.getScm(),
-                "p4User,p4Client,p4Port,p4Label,p4Exe,p4SysRoot,p4SysDrive,forceSync,alwaysForceSync,dontUpdateClient,updateView,slaveClientNameFormat,lineEndValue,firstChange,p4Counter,updateCounterValue,exposeP4Passwd,useViewMaskForPolling,viewMask,useViewMaskForSyncing,p4Charset,p4CommandCharset,p4Stream,useStreamDepot");
+                "p4User,p4Client,p4Port,p4Label,p4Exe,p4SysRoot,p4SysDrive,forceSync,alwaysForceSync,dontUpdateClient,createWorkspace,updateView,slaveClientNameFormat,lineEndValue,firstChange,p4Counter,updateCounterValue,exposeP4Passwd,useViewMaskForPolling,viewMask,useViewMaskForSyncing,p4Charset,p4CommandCharset,p4Stream,useStreamDepot");
         assertEquals("exclude_user", scm.getExcludedUsers());
         assertEquals("exclude_file", scm.getExcludedFiles());
         //assertEqualBeans(scm.getBrowser(),p.getScm().getBrowser(),"URL");
@@ -65,7 +65,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         String password = "pass";
         PerforceSCM scm = new PerforceSCM(
         		"user", password, "client", "port", "", "exe", "sysRoot",
-        		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, true, false,
+        		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, true, true, false,
                         false, true, false, false, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file");
         scm.setProjectPath("path");
         project.setScm(scm);
@@ -75,7 +75,7 @@ public class PerforceSCMTest extends HudsonTestCase {
 
         // verify that the data is intact
         assertEqualBeans(scm, project.getScm(),
-                "p4User,p4Client,p4Port,p4Label,projectPath,p4Exe,p4SysRoot,p4SysDrive,forceSync,alwaysForceSync,dontUpdateClient,updateView,slaveClientNameFormat,lineEndValue,firstChange,p4Counter,updateCounterValue,exposeP4Passwd,useViewMaskForPolling,viewMask,useViewMaskForSyncing,p4Charset,p4CommandCharset,p4Stream,useStreamDepot");
+                "p4User,p4Client,p4Port,p4Label,projectPath,p4Exe,p4SysRoot,p4SysDrive,forceSync,alwaysForceSync,dontUpdateClient,createWorkspace,updateView,slaveClientNameFormat,lineEndValue,firstChange,p4Counter,updateCounterValue,exposeP4Passwd,useViewMaskForPolling,viewMask,useViewMaskForSyncing,p4Charset,p4CommandCharset,p4Stream,useStreamDepot");
         assertEquals("exclude_user", scm.getExcludedUsers());
         assertEquals("exclude_file", scm.getExcludedFiles());
 
@@ -90,7 +90,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         String password = "pass";
         PerforceSCM scm = new PerforceSCM(
         		"user", password, "client", "port", "", "exe", "sysRoot",
-        		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, true, false,
+        		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, true, true, false,
                         false, true, false, false, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file");
         scm.setProjectPath("path");
         project.setScm(scm);
@@ -104,7 +104,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         String password = "pass";
         PerforceSCM scm = new PerforceSCM(
         		"user", password, "client", "port", "", "exe", "sysRoot",
-        		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, true, false,
+        		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, true, true, false,
                         false, true, false, false, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file");
         scm.setProjectPath("path");
         project.setScm(scm);
@@ -115,7 +115,7 @@ public class PerforceSCMTest extends HudsonTestCase {
 
         // verify that the data is intact
         assertEqualBeans(scm, project.getScm(),
-                "p4User,p4Client,p4Port,p4Label,projectPath,p4Exe,p4SysRoot,p4SysDrive,forceSync,alwaysForceSync,dontUpdateClient,updateView,slaveClientNameFormat,lineEndValue,firstChange,p4Counter,updateCounterValue,exposeP4Passwd,useViewMaskForPolling,viewMask,useViewMaskForSyncing,p4Charset,p4CommandCharset,p4Stream,useStreamDepot");
+                "p4User,p4Client,p4Port,p4Label,projectPath,p4Exe,p4SysRoot,p4SysDrive,forceSync,alwaysForceSync,dontUpdateClient,createWorkspace,updateView,slaveClientNameFormat,lineEndValue,firstChange,p4Counter,updateCounterValue,exposeP4Passwd,useViewMaskForPolling,viewMask,useViewMaskForSyncing,p4Charset,p4CommandCharset,p4Stream,useStreamDepot");
         assertEquals("exclude_user", scm.getExcludedUsers());
         assertEquals("exclude_file", scm.getExcludedFiles());
 


### PR DESCRIPTION
I added a checkbox above "Let Jenkins Manage Workspace View" that says "Let Jenkins Create Workspace".   Like the managing the view, it is true by default.

I need this so that I could let Jenkins create the workspace, but **not** manage the view after it is initially created.
