### PR TITLE
[JENKINS-10125]  Concurrent builds do not work when they execute on the same node simultaneously.

### DIFF
--- a/src/main/java/hudson/plugins/perforce/PerforceSCM.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceSCM.java
@@ -1541,9 +1541,11 @@ public class PerforceSCM extends SCM {
      */
     private String getConcurrentClientName(FilePath workspace, String p4Client) {
         if (workspace != null) {
-            int suffix_index = workspace.getRemote().lastIndexOf("@");
-            if (suffix_index > -1) {
-                p4Client += "_" + workspace.getRemote().substring(suffix_index+1);
+            //Match @ followed by an integer at the end of the workspace path
+            Pattern p = Pattern.compile(".*@(\\d+)$");
+            Matcher matcher = p.matcher(workspace.getRemote());
+            if (matcher.find()) {
+                p4Client += "_" + matcher.group(1);
             }
         }
         return p4Client;


### PR DESCRIPTION
With these changes, p4 plugin will use a p4 workspace specific to each Jenkins workspace. I'm just appending the Jenkins workspace identifier to p4 workspace name. So fixing https://issues.jenkins-ci.org/browse/JENKINS-10125.

There's one problem, Jenkins uses @-character to separate workspaces for concurrent builds. It has a special meaning in Perforce. Looks like syncing against a depot syntax works just fine although the p4 workspace root contains @-character. But sync against local syntax fails as Perforce expands @ to its ASCII presentation %40 (http://www.perforce.com/perforce/doc.current/manuals/cmdref/o.fspecs.html):

```
[workspace@2] $ C:\apps\perforce\p4.exe -P 00634C74F5DFAC3F9C0322B39F0AAFE1 -s sync ffu/...@1892
Caught exception communicating with perforce. Errors encountered while syncing: error: Path 'c:\APPS\njen\jobs\demo\workspace%402\ffu/...' is not under client's root 'C:\APPS\njen\jobs\demo\workspace@2'.
```

Here I've used "View mask" to sync only "ffu/..." path (although the view mask help says to use depot syntax it supports also local syntax). 

Any idea how to fix this?

Also, I would have liked to create a test case for this. Running two concurrent builds and checking that they used different p4 workspaces. I guess this would fail on Jenkins CI to missing p4? I wonder how I could simulate this behavior without really executing p4.
