### PR TITLE
[JENKINS-13109] Huge changelogs eat all the Java memory

### DIFF
--- a/src/main/java/com/tek42/perforce/parse/ChangelistBuilder.java
+++ b/src/main/java/com/tek42/perforce/parse/ChangelistBuilder.java
@@ -48,6 +48,12 @@ import com.tek42.perforce.model.Changelist;
  */
 public class ChangelistBuilder implements Builder<Changelist> {
 	private final Logger logger = LoggerFactory.getLogger("perforce");
+	//Maximum amount of files to be recorded to a changelist
+	private int maxFiles;
+	
+	public ChangelistBuilder(int maxFiles) {
+	    this.maxFiles = maxFiles;
+	}
 
 	public String[] getBuildCmd(String p4exe, String id) {
 		return new String[] { p4exe, "describe", "-s", id };
@@ -152,8 +158,16 @@ public class ChangelistBuilder implements Builder<Changelist> {
 				if(line.startsWith("Affected files")) {
 					logger.debug("reading files...");
 					List<Changelist.FileEntry> files = new ArrayList<Changelist.FileEntry>();
+			        int fileCount = 0;
 
 					while(lines.hasMoreElements()) {
+					    //Record a maximum of maxFiles files
+					    if(maxFiles > 0) {
+	                        if(fileCount >= maxFiles) {
+	                            break;
+	                        }
+					        fileCount++;
+					    }
 						String entry = lines.nextToken();
 						logger.debug("File Line: " + entry);
 						// if(!entry.startsWith("..."))

--- a/src/main/java/com/tek42/perforce/parse/Changes.java
+++ b/src/main/java/com/tek42/perforce/parse/Changes.java
@@ -59,12 +59,15 @@ public class Changes extends AbstractPerforceTemplate {
 	 * Returns a single changelist specified by its number.
 	 * 
 	 * @param number
+     * @param maxFiles 
+     *             The maximum number of affected files that will be recorded
+     *             to a changelist. With negative value include all the files.
 	 * @return
 	 * @throws PerforceException
 	 */
-	public Changelist getChangelist(int number) throws PerforceException {
+	public Changelist getChangelist(int number, int maxFiles) throws PerforceException {
 
-		ChangelistBuilder builder = new ChangelistBuilder();
+		ChangelistBuilder builder = new ChangelistBuilder(maxFiles);
 		Changelist change = builder.build(getPerforceResponse(builder.getBuildCmd(getP4Exe(), Integer.toString(number))));
 		if(change == null)
 			throw new PerforceException("Failed to retrieve changelist " + number);
@@ -111,10 +114,12 @@ public class Changes extends AbstractPerforceTemplate {
 	 *            The last changelist number to start from
 	 * @param limit
 	 *            The maximum changes to return if less than 1, will return everything
+	 * @param maxFiles 
+	 *            The maximum amount of affected files in a changelist to be recorded
 	 * @return
 	 * @throws PerforceException
 	 */
-	public List<Changelist> getChangelists(String path, int lastChange, int limit) throws PerforceException {
+	public List<Changelist> getChangelists(String path, int lastChange, int limit, int maxFiles) throws PerforceException {
 		path = normalizePath(path);
 		if(lastChange > 0)
 			path += "@" + lastChange;
@@ -132,7 +137,7 @@ public class Changes extends AbstractPerforceTemplate {
 		List<Changelist> changes = new ArrayList<Changelist>();
 		for(String id : ids) {
                     try{
-			changes.add(getChangelist(new Integer(id)));
+			changes.add(getChangelist(new Integer(id), maxFiles));
                     } catch(Exception e){
                         throw new PerforceException("Could not retrieve changelists.\nResponse from perforce was:\n" + response, e);
                     }
@@ -416,13 +421,16 @@ public class Changes extends AbstractPerforceTemplate {
 	 * Converts a list of numbers to a list of changes.
 	 * 
 	 * @param numbers
+	 * @param maxFiles 
+	 *             The maximum number of affected files that will be recorded
+	 *             to a changelist. With negative value include all the files.
 	 * @return
 	 * @throws PerforceException
 	 */
-	public List<Changelist> getChangelistsFromNumbers(List<Integer> numbers) throws PerforceException {
+	public List<Changelist> getChangelistsFromNumbers(List<Integer> numbers, int maxFiles) throws PerforceException {
 		List<Changelist> changes = new ArrayList<Changelist>();
 		for(Integer id : numbers) {
-			changes.add(getChangelist(id));
+			changes.add(getChangelist(id, maxFiles));
 		}
 		return changes;
 	}

--- a/src/main/resources/hudson/plugins/perforce/PerforceSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/perforce/PerforceSCM/config.jelly
@@ -121,6 +121,10 @@
               checkUrl="'${rootURL}/scm/PerforceSCM/checkChangeList?port='+escape(this.form.elements['p4Port'].value)+'&amp;tool='+escape(this.form.elements['p4Tool'].value)+'&amp;user='+escape(this.form.elements['p4User'].value)+'&amp;pass='+escape(this.form.elements['p4Passwd'].value)+'&amp;change='+escape(this.value)"/>
     </f:entry>
 
+    <f:entry title="Changelist file limit" help="/plugin/perforce/help/fileLimit.html">
+      <f:textbox field="fileLimit"/>
+    </f:entry>
+
     <f:entry title="Client Line Endings" help="/plugin/perforce/help/lineEnd.html">
         <select name="lineEndValue" id="lineEndValue">
             <j:forEach var="value" items="${instance==null?descriptor['allLineEndChoices']:instance['allLineEndChoices']}">

--- a/src/main/webapp/help/fileLimit.html
+++ b/src/main/webapp/help/fileLimit.html
@@ -1,0 +1,8 @@
+<div>
+    <p>
+        The maximum amount of affected files in a changelist that will be recorded to the detailed changes view. Empty value or 0 or negative value will list all the files in a changelist.
+    </p>
+    <p>
+        Limiting the amount of files can prevent out of memory errors.
+    </p>
+</div>

--- a/src/test/java/hudson/plugins/perforce/PerforceSCMTest.java
+++ b/src/test/java/hudson/plugins/perforce/PerforceSCMTest.java
@@ -27,7 +27,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         PerforceSCM scm = new PerforceSCM(
         		"user", "pass", "client", "port", "", "exe", "sysRoot",
         		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, true, true, false,
-                        false, true, false, false, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file", true);
+                        false, true, false, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true);
         scm.setProjectPath("path");
         project.setScm(scm);
 
@@ -36,7 +36,7 @@ public class PerforceSCMTest extends HudsonTestCase {
 
         // verify that the data is intact
         assertEqualBeans(scm, project.getScm(),
-                "p4User,p4Client,p4Port,p4Label,projectPath,p4Exe,p4SysRoot,p4SysDrive,forceSync,alwaysForceSync,dontUpdateClient,createWorkspace,updateView,slaveClientNameFormat,lineEndValue,firstChange,p4Counter,updateCounterValue,exposeP4Passwd,useViewMaskForPolling,viewMask,useViewMaskForSyncing,p4Charset,p4CommandCharset,p4Stream,useStreamDepot");
+                "p4User,p4Client,p4Port,p4Label,projectPath,p4Exe,p4SysRoot,p4SysDrive,forceSync,alwaysForceSync,dontUpdateClient,createWorkspace,updateView,slaveClientNameFormat,lineEndValue,firstChange,p4Counter,updateCounterValue,exposeP4Passwd,useViewMaskForPolling,viewMask,useViewMaskForSyncing,p4Charset,p4CommandCharset,p4Stream,useStreamDepot,fileLimit");
         assertEquals("exclude_user", scm.getExcludedUsers());
         assertEquals("exclude_file", scm.getExcludedFiles());
         //assertEqualBeans(scm.getBrowser(),p.getScm().getBrowser(),"URL");
@@ -48,7 +48,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         PerforceSCM scm = new PerforceSCM(
         		"user", "pass", "client", "port", "", "exe", "sysRoot",
         		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, true, true, false,
-                        false, true, false, false, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file", true);
+                        false, true, false, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true);
         scm.setP4Stream("stream");
         scm.setUseStreamDepot(true);
         project.setScm(scm);
@@ -75,7 +75,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         PerforceSCM scm = new PerforceSCM(
         		"user", password, "client", "port", "", "test_installation", "sysRoot",
         		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, true, true, false,
-                        false, true, false, false, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file", true);
+                        false, true, false, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true);
         scm.setProjectPath("path");
         project.setScm(scm);
 
@@ -84,7 +84,7 @@ public class PerforceSCMTest extends HudsonTestCase {
 
         // verify that the data is intact
         assertEqualBeans(scm, project.getScm(),
-                "p4User,p4Client,p4Port,p4Label,projectPath,p4Tool,p4SysRoot,p4SysDrive,forceSync,alwaysForceSync,dontUpdateClient,updateView,slaveClientNameFormat,lineEndValue,firstChange,p4Counter,updateCounterValue,exposeP4Passwd,useViewMaskForPolling,viewMask,useViewMaskForSyncing,p4Charset,p4CommandCharset,p4Stream,useStreamDepot");
+                "p4User,p4Client,p4Port,p4Label,projectPath,p4Tool,p4SysRoot,p4SysDrive,forceSync,alwaysForceSync,dontUpdateClient,updateView,slaveClientNameFormat,lineEndValue,firstChange,p4Counter,updateCounterValue,exposeP4Passwd,useViewMaskForPolling,viewMask,useViewMaskForSyncing,p4Charset,p4CommandCharset,p4Stream,useStreamDepot,fileLimit");
         assertEquals("exclude_user", scm.getExcludedUsers());
         assertEquals("exclude_file", scm.getExcludedFiles());
 
@@ -104,7 +104,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         PerforceSCM scm = new PerforceSCM(
         		"user", password, "client", "port", "", "test_installation", "sysRoot",
         		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, true, true, false,
-                        false, true, false, false, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file", true);
+                        false, true, false, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true);
         scm.setProjectPath("path");
         project.setScm(scm);
 
@@ -122,7 +122,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         PerforceSCM scm = new PerforceSCM(
         		"user", password, "client", "port", "", "test_installation", "sysRoot",
         		"sysDrive", "label", "counter", "shared", "charset", "charset2", false, true, true, true, true, true, false,
-                        false, true, false, false, false, false, "${basename}", 0, browser, "exclude_user", "exclude_file", true);
+                        false, true, false, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true);
         scm.setProjectPath("path");
         project.setScm(scm);
 
@@ -132,7 +132,7 @@ public class PerforceSCMTest extends HudsonTestCase {
 
         // verify that the data is intact
         assertEqualBeans(scm, project.getScm(),
-                "p4User,p4Client,p4Port,p4Label,projectPath,p4Tool,p4SysRoot,p4SysDrive,forceSync,alwaysForceSync,dontUpdateClient,updateView,slaveClientNameFormat,lineEndValue,firstChange,p4Counter,updateCounterValue,exposeP4Passwd,useViewMaskForPolling,viewMask,useViewMaskForSyncing,p4Charset,p4CommandCharset,p4Stream,useStreamDepot");
+                "p4User,p4Client,p4Port,p4Label,projectPath,p4Tool,p4SysRoot,p4SysDrive,forceSync,alwaysForceSync,dontUpdateClient,updateView,slaveClientNameFormat,lineEndValue,firstChange,p4Counter,updateCounterValue,exposeP4Passwd,useViewMaskForPolling,viewMask,useViewMaskForSyncing,p4Charset,p4CommandCharset,p4Stream,useStreamDepot,fileLimit");
         assertEquals("exclude_user", scm.getExcludedUsers());
         assertEquals("exclude_file", scm.getExcludedFiles());
 


### PR DESCRIPTION
Regarding https://issues.jenkins-ci.org/browse/JENKINS-13109. Perforce Changelist and FileEntry objects are reserving quite a lot of Java heap space. Limiting the amount of files shown for each changelist helps, especially with large changelists. Also I noticed that each FileEntry object for a Changelist owns a HashMap field for resolving the action type (add, edit, delete, ...). I'm sure this could be done smarter way, from memory consumption perspective.

Anyway, these changes helped our case. By default all the files are shown. It's bit poorly implemented in a way that with value 0 all the files are listed instead of not showing any files. 
