### PR TITLE
Parameter substitution fix for counter name.

### DIFF
--- a/src/main/java/hudson/plugins/perforce/PerforceSCM.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceSCM.java
@@ -914,9 +914,10 @@ public class PerforceSCM extends SCM {
             if (p4Counter != null && updateCounterValue) {
                 // Set or create a counter to mark this change
                 Counter counter = new Counter();
-                counter.setName(p4Counter);
+                String counterName = substituteParameters(this.p4Counter, build);
+                counter.setName(counterName);
                 counter.setValue(newestChange);
-                log.println("Updating counter " + p4Counter + " to " + newestChange);
+                log.println("Updating counter " + counterName + " to " + newestChange);
                 depot.getCounters().saveCounter(counter);
             }
 


### PR DESCRIPTION
Parameter substitution does not work when an upstream project is creating a counter. It works when a downstream project uses the counter. Here's a fix.
