### PR TITLE
Add ability to use same change set as an upstream job

### DIFF
--- a/src/main/java/hudson/plugins/perforce/PerforceSCM.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceSCM.java
@@ -21,6 +21,7 @@ import static hudson.Util.fixNull;
 import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixRun;
 import hudson.model.*;
+import hudson.model.listeners.ItemListener;
 import hudson.remoting.VirtualChannel;
 import hudson.scm.ChangeLogParser;
 import hudson.scm.PollingResult;
@@ -29,6 +30,8 @@ import hudson.scm.SCMDescriptor;
 import hudson.scm.SCMRevisionState;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
+import hudson.tasks.BuildTrigger;
+import hudson.tasks.Messages;
 import hudson.util.FormValidation;
 import hudson.util.LogTaskListener;
 
@@ -75,6 +78,7 @@ public class PerforceSCM extends SCM {
     String projectOptions;
     String p4Label;
     String p4Counter;
+    String p4UpstreamProject;
     String p4Stream;
     String clientOwner;
 
@@ -276,6 +280,7 @@ public class PerforceSCM extends SCM {
             String p4SysDrive,
             String p4Label,
             String p4Counter,
+            String p4UpstreamProject,
             String lineEndValue,
             String p4Charset,
             String p4CommandCharset,
@@ -322,6 +327,8 @@ public class PerforceSCM extends SCM {
 
         this.p4Counter = Util.fixEmptyAndTrim(p4Counter);
         this.updateCounterValue = updateCounterValue;
+
+        this.p4UpstreamProject = Util.fixEmptyAndTrim(p4UpstreamProject);
 
         this.projectPath = Util.fixEmptyAndTrim(projectPath);
 
@@ -844,6 +851,24 @@ public class PerforceSCM extends SCM {
                 if (p4Label != null && !p4Label.trim().isEmpty()) {
                     newestChange = depot.getChanges().getHighestLabelChangeNumber(p4workspace, p4Label.trim(), p4WorkspacePath);
                 } else {
+                    if (p4UpstreamProject != null && p4UpstreamProject.length() > 0) {
+                        log.println("Using last successful or unstable build of upstream project " + p4UpstreamProject);
+                        Job job = Hudson.getInstance().getItemByFullName(p4UpstreamProject, Job.class);
+                        if (job == null) {
+                            throw new AbortException(
+                                    "Configured upstream job does not exist anymore: " + p4UpstreamProject + ". Please update your job configuration.");
+                        }
+                        Run upStreamRun = job.getLastSuccessfulBuild();
+                        int lastUpStreamChange = getLastChangeNoFirstChange(upStreamRun);
+                        if (lastUpStreamChange > 0) {
+                            log.println("Using P4 revision " + lastUpStreamChange + " from upstream project " + p4UpstreamProject);
+                            newestChange = lastUpStreamChange;
+                        } else {
+                            log.println("No P4 revision found in upstream project " + p4UpstreamProject);
+                            throw new AbortException(
+                                    "Configured upstream job has not been run yet: " + p4UpstreamProject + ". Please run it once befor launching a new build.");
+                        }
+                    } else
                     if (p4Counter != null && !updateCounterValue) {
                         //use a counter
                         String counterName;
@@ -1346,9 +1371,14 @@ public class PerforceSCM extends SCM {
     }
 
     public int getLastChange(Run build) {
-        // If we are starting a new hudson project on existing work and want to skip the prior history...
-        if (firstChange > 0)
-            return firstChange;
+    	// If we are starting a new hudson project on existing work and want to skip the prior history...
+    	if (firstChange > 0)
+    		return firstChange;
+
+    	return getLastChangeNoFirstChange(build);
+    }
+
+    private static int getLastChangeNoFirstChange(Run build) {
 
         // If we can't find a PerforceTagAction, we will default to 0.
 
@@ -1360,7 +1390,7 @@ public class PerforceSCM extends SCM {
         return action.getChangeNumber();
     }
 
-    private PerforceTagAction getMostRecentTagAction(Run build) {
+    private static PerforceTagAction getMostRecentTagAction(Run build) {
         if (build == null)
             return null;
 
@@ -1820,7 +1850,7 @@ public class PerforceSCM extends SCM {
         /**
          * Performs syntactical and permissions check on the P4Counter
          */
-        public FormValidation doValidateP4Counter(StaplerRequest req, @QueryParameter String counter) throws IOException, ServletException {
+        public FormValidation doValidateP4Counter(StaplerRequest req, @QueryParameter String counter) {
             counter= Util.fixEmptyAndTrim(counter);
             if (counter == null)
                 return FormValidation.ok();
@@ -1837,6 +1867,30 @@ public class PerforceSCM extends SCM {
                             "Error accessing perforce while checking counter: " + e.getLocalizedMessage());
                 }
             }
+            return FormValidation.ok();
+        }
+        
+        /**
+         * Checks to see if the specified project exists and has p4 info.
+         */
+        public FormValidation doValidateP4UpstreamProject(StaplerRequest req, @QueryParameter String project) throws IOException, ServletException {
+            project = Util.fixEmptyAndTrim(project);
+            if (project == null) {
+                // well, it is not really OK, but it means it will not be used, so no error
+                return FormValidation.ok();
+            }
+
+            Job job = Hudson.getInstance().getItemByFullName(project, Job.class);
+            if (job == null) {
+                return FormValidation.error(Messages.BuildTrigger_NoSuchProject(project, AbstractProject.findNearest(project).getName()));
+            }
+
+            Run upStreamRun = job.getLastSuccessfulBuild();
+            int lastUpStreamChange = getLastChangeNoFirstChange(upStreamRun);
+            if (lastUpStreamChange < 1) {
+                FormValidation.warning("No Perforce change found in this project");
+            }
+
             return FormValidation.ok();
         }
 
@@ -2067,6 +2121,29 @@ public class PerforceSCM extends SCM {
 
         public String getAppName() {
             return Hudson.getInstance().getDisplayName();
+        }
+
+        @Extension
+        public static class ItemListenerImpl extends ItemListener {
+            @Override
+            public void onRenamed(Item item, String oldName, String newName) {
+                for( Project<?,?> p : Hudson.getInstance().getProjects() ) {
+                    SCM scm = p.getScm();
+                    if (scm instanceof PerforceSCM) {
+                        PerforceSCM p4scm = (PerforceSCM) scm;
+                        if (oldName.equals(p4scm.p4UpstreamProject)) {
+                            p4scm.p4UpstreamProject = newName;
+                            try {
+                                p.save();
+                            } catch (IOException e) {
+                                LOGGER.log(Level.WARNING,
+                                        "Failed to persist project setting during rename from "
+                                                + oldName + " to " + newName, e);
+                            }
+                        }
+                    }
+                }
+            }
         }
 
     }
@@ -2469,6 +2546,20 @@ public class PerforceSCM extends SCM {
      */
     public void setP4Counter(String counter) {
         p4Counter = counter;
+    }
+    
+    /**
+     * @return the p4UpstreamProject
+     */
+    public String getP4UpstreamProject() {
+        return p4UpstreamProject;
+    }
+    
+    /**
+     * @param label the p4Label to set
+     */
+    public void setP4UpstreamProject(String project) {
+        p4UpstreamProject = project;
     }
 
     /**

--- a/src/main/resources/hudson/plugins/perforce/PerforceSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/perforce/PerforceSCM/config.jelly
@@ -161,6 +161,13 @@
     <f:entry title="Update counter to most recent changeset" help="/plugin/perforce/help/updateCounterValue.html">
       <f:checkbox field="updateCounterValue" default="false" />
     </f:entry>
+    
+    <j:invokeStatic var="hudsonInstance" className="hudson.model.Hudson" method="getInstance"/>
+    <j:invoke var="allProjects" on="${hudsonInstance}" method="getJobNames"/>
+    <f:entry title="Use Upstream Project revision" help="/plugin/perforce/help/p4UpstreamProject.html">
+      <f:editableComboBox id="p4UpstreamProject" field="p4UpstreamProject" items="${allProjects}"
+          checkUrl="'${rootURL}/scm/PerforceSCM/validateP4UpstreamProject?project='+escape(document.forms[1].p4UpstreamProject.value)"/>
+    </f:entry>
 
     <f:entry title="Don't update client workspace" help="/plugin/perforce/help/dontUpdateClient.html">
       <f:checkbox field="dontUpdateClient" default="false" />

--- a/src/main/webapp/help/p4UpstreamProject.html
+++ b/src/main/webapp/help/p4UpstreamProject.html
@@ -1,0 +1,13 @@
+<div>
+  <p>
+    Sync to the changeset of another project.
+  </p>
+  <p>
+    If a project name is entered here, the plugin will sync to the changeset
+    of this other project last succesful build instead of the most recent
+    changeset.
+    This feature can be used for downstream jobs to sync to the same revision
+    as the upstream job, for example when using copy artifact plugin to copy
+    this project last succesful artifacts.
+  </p>
+</div>


### PR DESCRIPTION
This adds a new setting in the advanced perforce configuration, that
contains
the name of another job. When syncing the workspace, we will sync to
the same
change as this other job last successful build.

(I would have liked to create a Jira issue first, but I cannot login for the moment)
