### PR TITLE
Explicit check of Java version via maven-enforcer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.6]</version>
+                                    <version>[1.6,1.7)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
Hello, 

I have added explicit Java 1.6 requirement to the *.pom file. It prevents "Class not found" exception during build via JDK 1.7. 

Hopefully, BuildHive checks configuration of the maven-enforcer plugin and selects appropriate java version...

Best regards,
Oleg Nenashev
R&D Engineer, Synopsys Inc.
www.synopsys.com

P.S: Proposed approach prevents JDK-1.7 build at all. It would be good to fix issue, but Hudson support requires much old (and outdated?) packages.
P.P.S: net.java.dev.jna:jna:3.2.3 package has corrupted checksum at both Maven Central and Jenkins repo. So, automatic clean build of perforce plugin seems to be impossible for any JDK.
