### PR TITLE
Added validation of client workspace name (via pattern from global configuration)

### DIFF
--- a/src/main/resources/hudson/plugins/perforce/PerforceSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/perforce/PerforceSCM/global.jelly
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8' ?> 
+<!--
+  - The MIT License
+  -
+  - Copyright (c) 2013, Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+  -
+  - OriginalFile: manage-project-roles.jelly
+  - Thomas Maurel & Romain Seguy, Manufacture Française des Pneumatiques Michelin,
+  - 
+  -
+  - Permission is hereby granted, free of charge, to any person obtaining a copy
+  - of this software and associated documentation files (the "Software"), to deal
+  - in the Software without restriction, including without limitation the rights
+  - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  - copies of the Software, and to permit persons to whom the Software is
+  - furnished to do so, subject to the following conditions:
+  -
+  - The above copyright notice and this permission notice shall be included in
+  - all copies or substantial portions of the Software.
+  -
+  - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  - THE SOFTWARE.
+  -->
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:section title="Perforce SCM">
+    <f:entry title="P4 Client name pattern"  help="/plugin/perforce/help/clientNamePattern.html">
+      <f:textbox name="p4.clientPattern" value="${descriptor.p4ClientPattern}"
+                 checkUrl="'${rootURL}/scm/PerforceSCM/validateNamePattern?value='+escape(this.value)"/>
+    </f:entry>
+  </f:section>
+</j:jelly>

--- a/src/main/webapp/help/clientNamePattern.html
+++ b/src/main/webapp/help/clientNamePattern.html
@@ -1,0 +1,13 @@
+<div>
+  <p>
+    Regular expression to check P4 client naming policies.
+  </p>
+  <p>
+    Examples:
+	<ul>
+		<li>.* - All patterns</li>
+		<li>Jenkins_.* - Workspace should start from Jenkins_ prefix</li>
+		<li>\$\{JOB_NAME}_\$\{NODE_NAME\}_[\S]* - require two variables and non-space charecters then</li>
+	</ul>
+  </p>
+</div>


### PR DESCRIPTION
Hello Rob, 

I've added validation of client workspace according to [JENKINS-18378](https://issues.jenkins-ci.org/browse/JENKINS-18378).
If you agree with such approach, I'll add "Prohibit creation of invalid workspaces" option, which will fail creation of new workspaces, which violate naming policy. By default, all validations will be disabled in order to preserve backward compatibility.

Several screenshots:
![globalconfig](https://f.cloud.github.com/assets/3000480/664492/7df4c418-d786-11e2-8f3e-cf86c5ba05ae.png)
![validationexample](https://f.cloud.github.com/assets/3000480/664504/b970bc04-d786-11e2-9d1b-e105f146bd77.png)

Best regards,
Oleg Nenashev
R&D Engineer, Synopsys Inc.
www.synopsys.com
