### PR TITLE
[FIXED JENKINS-19557] - Improved MacroStringHelper in order to avoid sub...

### DIFF
--- a/src/main/java/hudson/plugins/perforce/PerforceTagNotifier.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceTagNotifier.java
@@ -115,9 +115,9 @@ public class PerforceTagNotifier extends Notifier {
 
             String labelName, labelDesc, labelOwner;
             try {
-                labelName = MacroStringHelper.substituteParameters(rawLabelName, build);
-                labelDesc = MacroStringHelper.substituteParameters(rawLabelDesc, build);
-                labelOwner = MacroStringHelper.substituteParameters(rawLabelOwner, build);
+                labelName = MacroStringHelper.substituteParameters(rawLabelName, build, null);
+                labelDesc = MacroStringHelper.substituteParameters(rawLabelDesc, build, null);
+                labelOwner = MacroStringHelper.substituteParameters(rawLabelOwner, build, null);
             } catch (ParameterSubstitutionException ex) {
                 listener.getLogger().println("Parameter substitution error in label items. "+ex.getMessage());
                 return false;


### PR DESCRIPTION
Fix allows to avoid substitution errors in logs during buildEnv() and improves performance of the job.

Resolves https://issues.jenkins-ci.org/browse/JENKINS-19557
Signed-off-by: Oleg Nenashev nenashev@synopsys.com
