### PR TITLE
Show one change log entry when building an older change.

### DIFF
--- a/src/main/java/hudson/plugins/perforce/PerforceSCM.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceSCM.java
@@ -990,7 +990,7 @@ public class PerforceSCM extends SCM {
                 if (lastChange > newestChange) {
                     // If we're building an older change, display it anyway
                     // TODO: This can be considered inconsistent behavior
-                    lastChangeToDisplay = newestChange-1;
+                    lastChangeToDisplay = newestChange;
                 }
                     
                 List<Integer> changeNumbersTo;


### PR DESCRIPTION
Border condition fix. Without it two changes are shown.
