### PR TITLE
[IN_PROGRESS][FIXED JENKINS-19794] - Refactored P4PASSWD exposure prevention.

### DIFF
--- a/src/main/java/hudson/plugins/perforce/PerforceSCM.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceSCM.java
@@ -2221,6 +2221,16 @@ public class PerforceSCM extends SCM {
             return FormValidation.ok();
         }
 
+        public FormValidation doCheckExposeP4Passwd(StaplerRequest req) {
+            boolean optionIsEnabled = req.getParameter("exposeP4Passwd").equals("true");
+            if (passwordExposeDisabled && optionIsEnabled) {
+                return FormValidation.warning(
+                        hudson.plugins.perforce.Messages.PerforceSCM_exposePasswordIsDisabled());
+            }
+            
+            return FormValidation.ok();
+        }
+        
         public FormValidation doCheckViewMask(StaplerRequest req) {
             String view = Util.fixEmptyAndTrim(req.getParameter("viewMask"));
             if (view != null) {
@@ -2744,10 +2754,12 @@ public class PerforceSCM extends SCM {
     }
 
     /**
+     * Enables exposure of P4PASSWD variable.
+     * This option can be overridden by global settings. 
      * @param exposeP4Passwd True if the P4PASSWD value must be set in the environment
      */
     public void setExposeP4Passwd(boolean exposeP4Passwd) {
-        this.exposeP4Passwd =  getInstance().isPasswordExposeDisabled() ? false : exposeP4Passwd;
+        this.exposeP4Passwd =  exposeP4Passwd;
     }
 
     /**

--- a/src/main/resources/hudson/plugins/perforce/Messages.properties
+++ b/src/main/resources/hudson/plugins/perforce/Messages.properties
@@ -1,1 +1,6 @@
 PerforceToolInstallation.onLoaded=Checking p4 executable migration
+
+# PerforceSCM.java
+PerforceSCM.exposePasswordIsDisabled= \
+  The setting will be ignored due to Perforce SCM global configuration. \
+  Please consider usage of "Mask Passwords" Plugin instead.

--- a/src/main/resources/hudson/plugins/perforce/PerforceSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/perforce/PerforceSCM/config.jelly
@@ -28,17 +28,6 @@
         <f:password field="p4Passwd" id="p4Passwd"
             checkUrl="'${rootURL}/scm/PerforceSCM/validatePerforceLogin?port='+escape(this.form.elements['p4Port'].value)+'&amp;tool='+escape(this.form.elements['p4Tool'].value)+'&amp;user='+escape(this.form.elements['p4User'].value)+'&amp;pass='+escape(this.form.elements['p4Passwd'].value)"/>
       </f:entry>
-
-      <j:if test="${not descriptor.passwordExposeDisabled}">
-        <f:entry title="Expose P4PASSWD in environment" help="/plugin/perforce/help/exposeP4Passwd.html">
-            <f:checkbox field="exposeP4Passwd" default="false"/>
-        </f:entry>
-      </j:if>    
-      <j:if test="${descriptor.passwordExposeDisabled}">
-        <f:invisibleEntry >
-            <input type="hidden" name="exposeP4Passwd" value="false" />
-        </f:invisibleEntry>
-      </j:if>
     </table>
   </f:entry>
 
@@ -81,6 +70,10 @@
   </f:entry>
 
   <f:advanced>
+    <f:entry title="Expose P4PASSWD in environment" help="/plugin/perforce/help/exposeP4Passwd.html">        
+      <f:checkbox field="exposeP4Passwd" default="false"
+         checkUrl="'${rootURL}/scm/PerforceSCM/checkExposeP4Passwd?exposeP4Passwd='+escape(this.checked)"/>     
+    </f:entry>
 
     <f:entry title="P4 executable" field="p4Tool">
       <select name="p4Tool">


### PR DESCRIPTION
The new implementation allows editing of exposeP4PASSWD option and does not force its stored value in PerforceSCM.

Resolves https://issues.jenkins-ci.org/browse/JENKINS-19794

Signed-off-by: Oleg Nenashev nenashev@synopsys.com
