### PR TITLE
Proposed fix for JENKINS-21609

### DIFF
--- a/src/main/java/hudson/plugins/perforce/PerforceSCMHelper.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceSCMHelper.java
@@ -210,7 +210,11 @@ public final class PerforceSCMHelper {
 
     static public Pattern getTokenPattern(String str) {
         String regex;
-        regex = str.replaceAll("\\*", "([^/]*)");
+        regex = str.replaceAll("\\[(.*)\\]",
+                Matcher.quoteReplacement("\\[") +
+                "$1" + Matcher.quoteReplacement("\\]"));
+        regex = regex.replaceAll("\\-", Matcher.quoteReplacement("\\-"));
+        regex = regex.replaceAll("\\*", "([^/]*)");
         regex = regex.replaceAll("([^\\.])\\.([^\\.])", "$1\\\\.$2");
         regex = regex.replaceAll("\\.\\.\\.", "(.*)");
         regex = regex.replaceAll("%%[0-9]", "([^/]*)");

--- a/src/test/java/hudson/plugins/perforce/PerforceSCMHelperTest.java
+++ b/src/test/java/hudson/plugins/perforce/PerforceSCMHelperTest.java
@@ -137,6 +137,36 @@ public class PerforceSCMHelperTest extends TestCase {
                     "//Install/.../*$Sub.class",
                     "/home/jenkins/workspace/.../*$Sub.class",
                     "//Install/trunk/SomeClass$Sub.class"));
+            assertEquals("/home/jenkins/workspace/trunk/SomeFile.xml",
+                    PerforceSCMHelper.doMapping(
+                    "//[S-B_Src]/.../SomeFile.xml",
+                    "/home/jenkins/workspace/.../SomeFile.xml",
+                    "//[S-B_Src]/trunk/SomeFile.xml"));
+            assertEquals("/home/jenkins/workspace/trunk/SomeFile.xml",
+                    PerforceSCMHelper.doMapping(
+                    "//[-B_Src]/.../SomeFile.xml",
+                    "/home/jenkins/workspace/.../SomeFile.xml",
+                    "//[-B_Src]/trunk/SomeFile.xml"));
+            assertEquals("/home/jenkins/workspace/trunk/SomeFile.xml",
+                    PerforceSCMHelper.doMapping(
+                    "//[S-_Src]/.../SomeFile.xml",
+                    "/home/jenkins/workspace/.../SomeFile.xml",
+                    "//[S-_Src]/trunk/SomeFile.xml"));
+            assertEquals("/home/jenkins/workspace/trunk/SomeFile.xml",
+                    PerforceSCMHelper.doMapping(
+                    "//[-Src]/.../SomeFile.xml",
+                    "/home/jenkins/workspace/.../SomeFile.xml",
+                    "//[-Src]/trunk/SomeFile.xml"));
+            assertEquals("/home/jenkins/workspace/trunk/SomeFile.xml",
+                    PerforceSCMHelper.doMapping(
+                    "//[Src]/.../SomeFile.xml",
+                    "/home/jenkins/workspace/.../SomeFile.xml",
+                    "//[Src]/trunk/SomeFile.xml"));
+            assertEquals("/home/jenkins/workspace/trunk/SomeFile.xml",
+                    PerforceSCMHelper.doMapping(
+                    "//[]/.../SomeFile.xml",
+                    "/home/jenkins/workspace/.../SomeFile.xml",
+                    "//[]/trunk/SomeFile.xml"));
         }
 
 }


### PR DESCRIPTION
If the depot path contains characters which might be interpreted as a range in
the regex syntax, the plugin fails to check out such a path correctly. This
attempts to fix this by escaping left and right brackets, and the dash
character.
