### PR TITLE
Supplemental fix for JENKINS-21609

### DIFF
--- a/src/main/java/hudson/plugins/perforce/PerforceSCMHelper.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceSCMHelper.java
@@ -210,7 +210,7 @@ public final class PerforceSCMHelper {
 
     static public Pattern getTokenPattern(String str) {
         String regex;
-        regex = str.replaceAll("\\[(.*)\\]",
+        regex = str.replaceAll("\\[(.*?)\\]",
                 Matcher.quoteReplacement("\\[") +
                 "$1" + Matcher.quoteReplacement("\\]"));
         regex = regex.replaceAll("\\-", Matcher.quoteReplacement("\\-"));

--- a/src/test/java/hudson/plugins/perforce/PerforceSCMHelperTest.java
+++ b/src/test/java/hudson/plugins/perforce/PerforceSCMHelperTest.java
@@ -167,6 +167,11 @@ public class PerforceSCMHelperTest extends TestCase {
                     "//[]/.../SomeFile.xml",
                     "/home/jenkins/workspace/.../SomeFile.xml",
                     "//[]/trunk/SomeFile.xml"));
+            assertEquals("/home/jenkins/workspace/[some-directory]/[some-file].xml",
+                    PerforceSCMHelper.doMapping(
+                    "//[]/.../[some-file].xml",
+                    "/home/jenkins/workspace/.../[some-file].xml",
+                    "//[]/[some-directory]/[some-file].xml"));
         }
 
 }


### PR DESCRIPTION
The previous fix did not take into account the existence of multiple sequences
of [xyz] in the path. This commit fixes this.
