### PR TITLE
p4.prog reporting feature

### DIFF
--- a/src/main/java/com/tek42/perforce/Depot.java
+++ b/src/main/java/com/tek42/perforce/Depot.java
@@ -87,6 +87,8 @@ public class Depot {
 	private Status status;
 	private Groups groups;
 	private Counters counters;
+	private String programName;
+	private String programVersion;
 
 	public Depot() {
 		this(new DefaultExecutorFactory());
@@ -572,5 +574,20 @@ public class Depot {
             return newValue.equals(currentValue);
     }
 
+	public String getProgramName() {
+		return programName;
+	}
+
+	public void setProgramName(String prog) {
+		this.programName = prog;
+	}
+	
+	public String getProgramVersion() {
+		return programVersion;
+	}
+
+	public void setProgramVersion(String version) {
+		this.programVersion = version;
+	}
 	
 }

--- a/src/main/java/com/tek42/perforce/parse/AbstractPerforceTemplate.java
+++ b/src/main/java/com/tek42/perforce/parse/AbstractPerforceTemplate.java
@@ -147,22 +147,38 @@ public abstract class AbstractPerforceTemplate {
 	 * @return A (possibly) modified string array to be executed in place of the original.
 	 */
 	protected String[] getExtraParams(String cmd[]) {
+		List<String> newCmd = new ArrayList<String>();
+		
+		// Copy over p4 executable
+		newCmd.add(cmd[0]);
+		
+		String program = depot.getProgramName();
+		if (program != null) {
+			// Insert program to be reported to Perforce server
+			newCmd.add("-z");
+			newCmd.add("prog=" + program);
+		}
+		 
+		String version = depot.getProgramVersion();
+		if (version != null) {
+			// Insert version to be reported to Perforce server
+			newCmd.add("-z");
+			newCmd.add("version=" + version);
+		}
+		
 		String ticket = depot.getP4Ticket();
-
 		if(ticket != null) {
 			// Insert the ticket for the password if tickets are being used...
-			String newCmds[] = new String[cmd.length + 2];
-			newCmds[0] = getP4Exe();
-			newCmds[1] = "-P";
-			newCmds[2] = ticket;
-			for(int i = 3; (i - 2) < cmd.length; i++) {
-				newCmds[i] = cmd[i - 2];
-			}
-			cmd = newCmds;
-		} else {
-		    cmd[0] = getP4Exe();
+			newCmd.add("-P");
+			newCmd.add(ticket);
 		}
-		return cmd;
+		
+		// Append the remaining original parameters
+		for(int i = 1; i < cmd.length; i++) {
+			newCmd.add(cmd[i]);
+		}
+		
+		return newCmd.toArray(new String[newCmd.size()]);
 	}
 
 	/**

--- a/src/main/java/hudson/plugins/perforce/PerforceSCM.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceSCM.java
@@ -250,6 +250,17 @@ public class PerforceSCM extends SCM {
      *  Hash
      */
     String slaveClientNameFormat = null;
+    
+    /**
+     * Perforce program name to report to the Perforce server
+     */
+    String p4ProgramName = null;
+    String p4ProgramPollingName = null;
+	
+    /** Regular expression for validation of p4 Program Name 
+     */
+    private static final String P4_PROGRAM_NAME_PATTERN =
+    		"[_a-zA-Z0-9@.\\[\\]\\(\\)\\<\\>-]+";
 
     /**
      * We need to store the changelog file name for the build so that we can expose
@@ -423,6 +434,9 @@ public class PerforceSCM extends SCM {
         this.excludedUsers = Util.fixEmptyAndTrim(excludedUsers);
         this.excludedFiles = Util.fixEmptyAndTrim(excludedFiles);
         this.excludedFilesCaseSensitivity = excludedFilesCaseSensitivity;
+        
+        setP4ProgramName(p4ProgramName);
+        setP4ProgramPollingName(p4ProgramPollingName);
     }
     
     /**
@@ -891,6 +905,16 @@ public class PerforceSCM extends SCM {
         }
 
         try {
+        	String progName = getEffectiveP4ProgramName();
+        	if (progName != null) {
+        		log.println("p4.prog=" + progName);
+        		if (progName.matches(P4_PROGRAM_NAME_PATTERN)) {
+		        	depot.setProgramName(progName);
+        		} else {
+        			log.println("WARNING: p4.prog don't match " + P4_PROGRAM_NAME_PATTERN + " (ignoring it)");
+        		}
+        	}
+        	
             // keep projectPath local so any modifications for slaves don't get saved
             String projectPath;
             projectPath = getEffectiveProjectPath(build, build.getProject(), log, depot);
@@ -1302,6 +1326,16 @@ public class PerforceSCM extends SCM {
                 depot = getDepot(buildNode.createLauncher(listener),buildNode.getRootPath(),project,null, buildNode);
                 logger.println("Using node: " + buildNode.getDisplayName());
             }
+            
+            String progName = getEffectiveP4ProgramPollingName();
+            if (progName != null) {
+	        	logger.println("p4.prog=" + progName);
+	        	if (progName.matches(P4_PROGRAM_NAME_PATTERN)) {
+		        	depot.setProgramName(progName);
+        		} else {
+        			logger.println("WARNING: p4.prog don't match " + P4_PROGRAM_NAME_PATTERN + " (ignoring it)");
+        		}
+        	}
 
             Workspace p4workspace = getPerforceWorkspace(project, getEffectiveProjectPath(null, project, logger, depot), depot, buildNode, null, launcher, workspace, listener, true);
             saveWorkspaceIfDirty(depot, p4workspace, logger);
@@ -1851,6 +1885,9 @@ public class PerforceSCM extends SCM {
         private final static int P4_INFINITE_TIMEOUT_SEC = 0;
         private final static int P4_MINIMAL_TIMEOUT_SEC = 30;
         
+        private String p4ProgramNameDefault;
+        private String p4ProgramPollingNameDefault;
+        
         public PerforceSCMDescriptor() {
             super(PerforceSCM.class, PerforceRepositoryBrowser.class);
             load();
@@ -1925,6 +1962,9 @@ public class PerforceSCM extends SCM {
         public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
             p4ClientPattern = Util.fixEmpty(req.getParameter("p4.clientPattern").trim());
             passwordExposeDisabled = json.getBoolean("passwordExposeDisabled");
+            
+            p4ProgramNameDefault = Util.fixEmptyAndTrim(json.getString("p4ProgramNameDefault"));
+            p4ProgramPollingNameDefault = Util.fixEmptyAndTrim(json.getString("p4ProgramPollingNameDefault"));
             
             // ReadLine timeout
             String p4timeoutStr = Util.fixEmpty(req.getParameter("p4.readLineTimeout").trim());            
@@ -2326,6 +2366,17 @@ public class PerforceSCM extends SCM {
             }
             return FormValidation.ok();
         }
+        
+    	/**
+    	 * Limit allowed characters to prevent shell injection.
+    	 */
+        public FormValidation doValidateP4ProgramName(StaplerRequest req, @QueryParameter String p4prog) {
+            p4prog = Util.fixEmptyAndTrim(p4prog);
+            if (p4prog == null || p4prog.matches(P4_PROGRAM_NAME_PATTERN)) {
+            	return FormValidation.ok();
+            }
+            return FormValidation.error("Forbidden characters in string. Name shall match " + P4_PROGRAM_NAME_PATTERN);
+        }
 
         public List<String> getAllLineEndChoices() {
             List<String> allChoices = Arrays.asList(
@@ -2351,6 +2402,14 @@ public class PerforceSCM extends SCM {
             return Hudson.getInstance().getDisplayName();
         }
 
+        public String getP4ProgramNameDefault() {
+        	return p4ProgramNameDefault;
+        }
+        
+        public String getP4ProgramPollingNameDefault() {
+        	return p4ProgramPollingNameDefault;
+        }
+        
         @Extension
         public static class ItemListenerImpl extends ItemListener {
             @Override
@@ -3195,5 +3254,44 @@ public class PerforceSCM extends SCM {
     public boolean supportsPolling() {
         return true;
     }
+
+	public String getP4ProgramName() {
+		return p4ProgramName;
+	}
+
+	public void setP4ProgramName(String name) {
+		this.p4ProgramName = Util.fixEmptyAndTrim(name);
+	}
+
+	public String getP4ProgramPollingName() {
+		return p4ProgramPollingName;
+	}
+	
+	public void setP4ProgramPollingName(String name) {
+		this.p4ProgramPollingName = Util.fixEmptyAndTrim(name);
+	}
+	
+	public String getEffectiveP4ProgramName() {
+		String name = getP4ProgramName();
+		if (name == null) {
+			name = ((PerforceSCMDescriptor)getDescriptor()).getP4ProgramNameDefault();
+		}
+		return Util.fixEmptyAndTrim(name);
+	}
+	
+	public String getEffectiveP4ProgramPollingName() {
+		String name = getP4ProgramPollingName();
+		if (name == null) {
+			name = getP4ProgramName();
+		}
+		if (name == null) {  // Falback to global config
+			PerforceSCMDescriptor desc = (PerforceSCMDescriptor)getDescriptor();			
+			name = desc.getP4ProgramPollingNameDefault();
+			if (name == null) {
+				name = desc.getP4ProgramNameDefault();
+			}
+		} 
+		return Util.fixEmptyAndTrim(name);
+	}
 
 }

--- a/src/main/resources/hudson/plugins/perforce/PerforceSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/perforce/PerforceSCM/config.jelly
@@ -246,6 +246,17 @@
             <f:checkbox name="p4.useViewMaskForChangeLog" checked="${instance.useViewMaskForChangeLog}"/>
         </f:entry>
     </f:optionalBlock>
+    
+    <f:entry title="p4 Program Name" help="/plugin/perforce/help/p4ProgramName.html">
+      <f:textbox field="p4ProgramName" id="p4ProgramName" 
+        checkUrl="'${rootURL}/scm/PerforceSCM/validateP4ProgramName?p4prog='+escape(this.form.elements['p4ProgramName'].value)"/>
+    </f:entry>
+    
+    <f:entry title="p4 Program Polling Name" help="/plugin/perforce/help/p4ProgramPollingName.html">
+      <f:textbox field="p4ProgramPollingName" id="p4ProgramPollingName"
+        checkUrl="'${rootURL}/scm/PerforceSCM/validateP4ProgramName?p4prog='+escape(this.form.elements['p4ProgramPollingName'].value)"/>
+    </f:entry>
+    
   </f:advanced>
 
   <t:listScmBrowsers name="browser" />

--- a/src/main/resources/hudson/plugins/perforce/PerforceSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/perforce/PerforceSCM/global.jelly
@@ -41,6 +41,16 @@
         <f:checkbox name="p4.passwordExposeDisabled" checked="${descriptor.passwordExposeDisabled}"/>
         <f:description>Option globally disables exposal of Perforce passwords</f:description>
     </f:entry>
-        
+    
+    <f:entry title="p4 Program Name Default" help="/plugin/perforce/help/p4ProgramNameDefault.html">
+      <f:textbox field="p4ProgramNameDefault" id="p4ProgramNameDefault"
+        checkUrl="'${rootURL}/scm/PerforceSCM/validateP4ProgramName?p4prog='+escape(this.form.elements['p4ProgramNameDefault'].value)"/>
+    </f:entry>
+    
+    <f:entry title="p4 Program Polling Name Default" help="/plugin/perforce/help/p4ProgramPollingNameDefault.html">
+      <f:textbox field="p4ProgramPollingNameDefault" id="p4ProgramPollingNameDefault"
+        checkUrl="'${rootURL}/scm/PerforceSCM/validateP4ProgramName?p4prog='+escape(this.form.elements['p4ProgramPollingNameDefault'].value)"/>
+    </f:entry>
+    
   </f:section>
 </j:jelly>

--- a/src/main/webapp/help/p4ProgramName.html
+++ b/src/main/webapp/help/p4ProgramName.html
@@ -1,0 +1,13 @@
+<div>
+  <p>
+    Set what Program Name shall be reported to Perforce server.
+  </p>
+  <p>
+    Setting this value will add extra option "-z prog=name" every time 
+    p4 is connecting to the Perforce server. This can be later examined 
+    with p4 monitor by Perforce administrators. 
+    
+    Useful to debug Perforce connections, group then together and identify 
+    their source.
+  </p>
+</div>

--- a/src/main/webapp/help/p4ProgramNameDefault.html
+++ b/src/main/webapp/help/p4ProgramNameDefault.html
@@ -1,0 +1,15 @@
+<div>
+  <p>
+    Set what Program Name shall be reported to Perforce server.
+  </p>
+  <p>
+    Setting this value will add extra option "-z prog=name" every time 
+    p4 is connecting to the Perforce server. This can be later examined 
+    with p4 monitor command by Perforce administrators.
+    Useful to debug Perforce connections, group then together and identify 
+    their source.
+    
+    This is a global setting that will be used for all Jenkins jobs, unless 
+    not explicitly overridden in job specific Perforce configuration.
+  </p>
+</div>

--- a/src/main/webapp/help/p4ProgramPollingName.html
+++ b/src/main/webapp/help/p4ProgramPollingName.html
@@ -1,0 +1,16 @@
+<div>
+  <p>
+    Set what Program Name shall be reported to Perforce server when job is 
+    polling for new changes.
+  </p>
+  <p>
+    This field's value will be used when polling for new changes.
+    If not set, the value of "p4 Program Name" field will be used.
+    Use it when you would like to have granular identification of what 
+    connections are tied with polling and what with fetching stages.  
+    
+    There is also corresponding "p4 Program Default Polling Name" option at 
+    Jenkins global configuration. Although before that is used, the local 
+    "p4 Program Name", if set, takes precedence. 
+  </p>
+</div>

--- a/src/main/webapp/help/p4ProgramPollingNameDefault.html
+++ b/src/main/webapp/help/p4ProgramPollingNameDefault.html
@@ -1,0 +1,26 @@
+<div>
+  <p>
+    Set what Program Name shall be reported to Perforce server when job is
+    polling for new changes.
+  </p>
+  <p>
+    This field's value will be used when polling for new changes.
+    If not set, the value of "p4 Program Name" field will be used.
+    Use it when you would like to have granular identification of what 
+    connections are tied with polling and what with fetching sources.
+    
+    This is a global setting that will be used for all Jenkins jobs, unless 
+    not explicitly overridden in job specific Perforce configuration.
+    
+    This option is overridden by both job specific settings related to this 
+    feature, i.e. "p4 Program Polling Name" and "p4 Program Name".
+    
+    The effective value resolution order is:
+    <pre>
+    job specific p4 "Program Polling Name"
+    else job specific p4 "Program Name"
+    else global p4 "Program Polling Name"
+    else global p4 "Program Name"
+    </pre>
+  </p>
+</div>

--- a/src/test/java/hudson/plugins/perforce/PerforceSCMTest.java
+++ b/src/test/java/hudson/plugins/perforce/PerforceSCMTest.java
@@ -60,7 +60,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         PerforceSCM scm = new PerforceSCM(
                         "user", "pass", "client", "port", "", "exe", "",
                         "", "label", "counter", "upstreamProject", "shared", "charset", "charset2", "user", false, true, true, true, true, true, false,
-                        false, true, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true, EMPTY_DEPOT, EMPTY_WORKSPACE_CLEANUP, EMPTY_MASKVIEW);
+                        false, true, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true, EMPTY_DEPOT, EMPTY_WORKSPACE_CLEANUP, EMPTY_MASKVIEW, null, null);
         assertEquals("", scm.getP4SysDrive());
         assertEquals("", scm.getP4SysRoot());
         scm.setProjectPath("path");
@@ -80,7 +80,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         PerforceSCM scm = new PerforceSCM(
         		"user", "pass", "client", "port", "", "exe", "sysRoot",
         		"sysDrive", "label", "counter", "upstreamProject", "shared", "charset", "charset2", "user", false, true, true, true, true, true, false,
-                        false, true, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true, EMPTY_DEPOT, EMPTY_WORKSPACE_CLEANUP, EMPTY_MASKVIEW);
+                        false, true, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true, EMPTY_DEPOT, EMPTY_WORKSPACE_CLEANUP, EMPTY_MASKVIEW, null, null);
         scm.setP4Stream("stream");
         scm.setUseStreamDepot(true);
         project.setScm(scm);
@@ -107,7 +107,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         PerforceSCM scm = new PerforceSCM(
         		"user", password, "client", "port", "", "test_installation", "sysRoot",
         		"sysDrive", "label", "counter", "upstreamProject", "shared", "charset", "charset2", "user", false, true, true, true, true, true, false,
-                        false, true, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true, EMPTY_DEPOT, EMPTY_WORKSPACE_CLEANUP, EMPTY_MASKVIEW);
+                        false, true, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true, EMPTY_DEPOT, EMPTY_WORKSPACE_CLEANUP, EMPTY_MASKVIEW, null, null);
         scm.setProjectPath("path");
         project.setScm(scm);
 
@@ -136,7 +136,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         PerforceSCM scm = new PerforceSCM(
         		"user", password, "client", "port", "", "test_installation", "sysRoot",
         		"sysDrive", "label", "counter", "upstreamProject", "shared", "charset", "charset2", "user", false, true, true, true, true, true, false,
-                        false, true, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true, EMPTY_DEPOT, EMPTY_WORKSPACE_CLEANUP, EMPTY_MASKVIEW);
+                        false, true, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true, EMPTY_DEPOT, EMPTY_WORKSPACE_CLEANUP, EMPTY_MASKVIEW, null, null);
         scm.setProjectPath("path");
         project.setScm(scm);
 
@@ -154,7 +154,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         PerforceSCM scm = new PerforceSCM(
         		"user", password, "client", "port", "", "test_installation", "sysRoot",
         		"sysDrive", "label", "counter", "upstreamProject", "shared", "charset", "charset2", "user", false, true, true, true, true, true, false,
-                        false, true, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true, EMPTY_DEPOT, EMPTY_WORKSPACE_CLEANUP, EMPTY_MASKVIEW);
+                        false, true, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true, EMPTY_DEPOT, EMPTY_WORKSPACE_CLEANUP, EMPTY_MASKVIEW, null, null);
         scm.setProjectPath("path");
         project.setScm(scm);
 
@@ -336,7 +336,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         PerforceSCM scm = new PerforceSCM(
                 "user", password, "client", "port", "", "test_installation", "sysRoot",
                 "sysDrive", "label", "counter", "upstreamProject", "shared", "charset", "charset2", "user", false, true, true, true, true, true, false,
-                        false, false, true, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true, EMPTY_DEPOT, EMPTY_WORKSPACE_CLEANUP, EMPTY_MASKVIEW);
+                        false, false, true, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true, EMPTY_DEPOT, EMPTY_WORKSPACE_CLEANUP, EMPTY_MASKVIEW, null, null);
         scm.setP4Stream("stream");
         project.setScm(scm);
 
@@ -374,7 +374,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         PerforceSCM upstreamScm = new PerforceSCM(
                 "user", "pass", "client", "port", "", "test_installation", "sysRoot",
                 "sysDrive", null, null, null, "shared", "charset", "charset2", "user", false, true, true, true, true, true, false,
-                        false, true, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true, EMPTY_DEPOT, EMPTY_WORKSPACE_CLEANUP, EMPTY_MASKVIEW);
+                        false, true, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true, EMPTY_DEPOT, EMPTY_WORKSPACE_CLEANUP, EMPTY_MASKVIEW, null, null);
         upstreamScm.setProjectPath("path");
         upstreamProject.setScm(upstreamScm);
         
@@ -383,7 +383,7 @@ public class PerforceSCMTest extends HudsonTestCase {
         PerforceSCM downstreamScm = new PerforceSCM(
                 "user", "pass", "client", "port", "", "test_installation", "sysRoot",
                 "sysDrive", null, null, oldName, "shared", "charset", "charset2", "user", false, true, true, true, true, true, false,
-                        false, true, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true, EMPTY_DEPOT, EMPTY_WORKSPACE_CLEANUP, EMPTY_MASKVIEW);
+                        false, true, false, false, false, "${basename}", 0, -1, browser, "exclude_user", "exclude_file", true, EMPTY_DEPOT, EMPTY_WORKSPACE_CLEANUP, EMPTY_MASKVIEW, null, null);
         downstreamScm.setProjectPath("path");
         downstreamProject.setScm(downstreamScm);
 


### PR DESCRIPTION
This patch provides capability to report custom p4 program name to the Perforce server.

p4.prog is an arbitrary string which identifies the application establishing connection to p4 server. It can be later traced in server logs as well as with p4 monitor. It is very useful if you have several automated systems connecting to p4 server, and you want to be able to easily trace and account them.

Javadoc is pretty scanty about the parameter, below link to python docs:
http://www.perforce.com/perforce/doc.current/manuals/p4script/03_python.html#1120041
