### PR TITLE
Fix for JENKINS-11600, email-ext now queries getTimestamp and getCommite...

### DIFF
--- a/src/main/java/hudson/plugins/perforce/PerforceChangeLogEntry.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceChangeLogEntry.java
@@ -65,7 +65,12 @@ public class PerforceChangeLogEntry extends ChangeLogSet.Entry {
     }
 
     //used for email-ext
+    @Deprecated
     public String getRevision() {
+        return getChangeNumber();
+    }
+    //used for email-ext
+    public String getCommitId() {
         return getChangeNumber();
     }
 
@@ -76,9 +81,15 @@ public class PerforceChangeLogEntry extends ChangeLogSet.Entry {
     }
 
     //used for email-ext
+    @Deprecated
     public String getDate() {
         return getChangeTime();
     }
+    //used for email-ext
+    public long getTimestamp() {
+        return getChange().getDate().getTime();
+    }
+
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
Fixed issues for null and Jan 1, 1970 1:59:59 AM being retrieved by email-ext plugin.
