### PR TITLE
Fixing build parameters not being expanded in slave client name format

### DIFF
--- a/src/main/java/hudson/plugins/perforce/PerforceSCM.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceSCM.java
@@ -1713,20 +1713,20 @@ public class PerforceSCM extends SCM {
         Node buildNode = build.getBuiltOn();
         FilePath workspace = build.getWorkspace();
         String p4Client = this.p4Client;
-        p4Client = MacroStringHelper.substituteParameters(p4Client, build, env);
         try {
             p4Client = getEffectiveClientName(p4Client, buildNode);
         } catch (Exception e) {
             new StreamTaskListener(System.out).getLogger().println(
                     "Could not get effective client name: " + e.getMessage());
         }
+        p4Client = MacroStringHelper.substituteParameters(p4Client, build, env);
         return p4Client;
     }
 
     private String getDefaultEffectiveClientName(AbstractProject project, Node buildNode, FilePath workspace)
             throws IOException, InterruptedException {
-        String basename = MacroStringHelper.substituteParametersNoCheck(this.p4Client, getDefaultSubstitutions(project));
-        return getEffectiveClientName(basename, buildNode);
+        String basename = getEffectiveClientName(this.p4Client, buildNode);
+        return MacroStringHelper.substituteParametersNoCheck(basename, getDefaultSubstitutions(project));
     }
 
     private String getEffectiveClientName(String basename, Node buildNode)


### PR DESCRIPTION
swapping order of param substitution when getting effective client name so build parameters put in the slave client name format are substituted.
