### PR TITLE
[JENKINS-28367] Add error message to allow fallback to 'p4 login -p'.

### DIFF
--- a/src/main/java/com/tek42/perforce/parse/AbstractPerforceTemplate.java
+++ b/src/main/java/com/tek42/perforce/parse/AbstractPerforceTemplate.java
@@ -65,6 +65,7 @@ public abstract class AbstractPerforceTemplate {
             "You don't have permission for this operation.",
             "Password invalid.",
             "The authenticity of",
+            "User not allowed to create a ticket that is valid on all host machines.",
         };
     
     private static final int P4_EXECUTOR_CHECK_PERIOD = 2000;


### PR DESCRIPTION
checkAuthnErrors was not detecting the error message for 'p4 login -a
-p' when the '-a' option is not allowed by the server.  Added the
message to p4errors so that a PerforceException would be thrown and
cause the fallback implemented in 55762a90 to occur.