### PR TITLE
 Primitives should not be boxed just for "String" conversion

### DIFF
--- a/src/main/java/hudson/plugins/perforce/PerforceChangeLogEntry.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceChangeLogEntry.java
@@ -58,7 +58,7 @@ public class PerforceChangeLogEntry extends ChangeLogSet.Entry {
 
     @Exported
     public String getChangeNumber() {
-        return new Integer(getChange().getChangeNumber()).toString();
+        return String.valueOf(getChange().getChangeNumber());
     }
 
     //used for email-ext

--- a/src/main/java/hudson/plugins/perforce/PerforceChangeLogParser.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceChangeLogParser.java
@@ -263,6 +263,6 @@ public class PerforceChangeLogParser extends ChangeLogParser {
         if (i < 10) {
             return "0" + i;
         }
-        return i + "";
+        return String.valueOf(i);
     }
 }

--- a/src/main/java/hudson/plugins/perforce/PerforceSCM.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceSCM.java
@@ -3204,7 +3204,7 @@ public class PerforceSCM extends SCM {
     public String getFirstChange() {
         if (firstChange <= 0)
             return "";
-        return Integer.valueOf(firstChange).toString();
+        return String.valueOf(firstChange);
     }
 
     /**
@@ -3218,7 +3218,7 @@ public class PerforceSCM extends SCM {
     public String getFileLimit() {
         if (fileLimit <= 0)
             return "";
-        return Integer.valueOf(fileLimit).toString();
+        return String.valueOf(fileLimit);
     }
 
     public void setFileLimit(int fileLimit) {

--- a/src/main/java/hudson/plugins/perforce/PerforceTagAction.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceTagAction.java
@@ -182,7 +182,7 @@ public class PerforceTagAction extends AbstractScmTagAction {
         Label label = new Label();
         label.setName(tagname);
         label.setDescription(description);
-        label.setRevision(new Integer(changeNumber).toString());
+        label.setRevision(String.valueOf(changeNumber));
         if(owner!=null && !owner.equals("")) label.setOwner(owner);
 
         PerforceSCM scm = getSCM();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - “Primitives should not be boxed just for "String" conversion”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
Ayman Abdelghany.