### PR TITLE
Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/src/main/java/com/perforce/api/Change.java
+++ b/src/main/java/com/perforce/api/Change.java
@@ -434,7 +434,7 @@ public final class Change extends SourceControlObject {
 			}
 			p.println("Description: ");
 			p.println(getDescription());
-			if(null != fents && 0 < fents.size()) {
+			if(null != fents && !fents.isEmpty()) {
 				FileEntry fent;
 				p.println("Files: ");
 				en = fents.elements();
@@ -713,7 +713,7 @@ public final class Change extends SourceControlObject {
 
 		Vector v = getFileEntries();
 		FileEntry fent = null;
-		if(null != v && 0 != v.size()) {
+		if(null != v && !v.isEmpty()) {
 			sb.append("<files>");
 			for(int i = 0; i < v.size(); i++) {
 				fent = (FileEntry) v.elementAt(i);
@@ -772,7 +772,7 @@ public final class Change extends SourceControlObject {
 		} catch(Exception ex) {
 			throw new PerforceException(ex.getMessage());
 		}
-		if(0 == users.size())
+		if(users.isEmpty())
 			return null;
 		return (User[]) users.toArray(usrs);
 	}

--- a/src/main/java/com/perforce/api/Counter.java
+++ b/src/main/java/com/perforce/api/Counter.java
@@ -177,7 +177,7 @@ public final class Counter extends SourceControlObject {
 			}
 			throw new PerforceException(ex.getMessage());
 		}
-		if(0 == v.size())
+		if(v.isEmpty())
 			return null;
 		return (Counter[]) v.toArray(new Counter[0]);
 	}
@@ -238,7 +238,7 @@ public final class Counter extends SourceControlObject {
 			}
 			throw new PerforceException(ex.getMessage());
 		}
-		if(0 == v.size())
+		if(v.isEmpty())
 			return null;
 		return (Change[]) v.toArray(new Change[0]);
 	}

--- a/src/main/java/com/tek42/perforce/model/Changelist.java
+++ b/src/main/java/com/tek42/perforce/model/Changelist.java
@@ -66,13 +66,13 @@ public class Changelist implements java.io.Serializable {
 		sb.append("by " + user + "@" + workspace + "\n");
 		sb.append("on " + date + "\n");
 		sb.append("Description:\n" + description + "\n");
-		if(jobs.size() > 0) {
+		if(!jobs.isEmpty()) {
 			sb.append("Jobs: \n");
 			for(JobEntry job : jobs) {
 				sb.append(job + "\n");
 			}
 		}
-		if(files.size() > 0) {
+		if(!files.isEmpty()) {
 			sb.append("Files: \n");
 			for(FileEntry file : files) {
 				sb.append(file + "\n");

--- a/src/main/java/com/tek42/perforce/parse/Changes.java
+++ b/src/main/java/com/tek42/perforce/parse/Changes.java
@@ -319,7 +319,7 @@ public class Changes extends AbstractPerforceTemplate {
 				throw e;
 			}
 			List<String> temp = parseList(response, 1);
-			if(temp.size() == 0)
+			if(temp.isEmpty())
 				break;
 			for(String num : temp) {
 				if(new Integer(num) >= untilChange)

--- a/src/main/java/hudson/plugins/perforce/PerforceSCM.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceSCM.java
@@ -1009,11 +1009,11 @@ public class PerforceSCM extends SCM {
                     //use the latest submitted change from workspace, or depot
                     try {
                         List<Integer> workspaceChanges = depot.getChanges().getChangeNumbers(p4WorkspacePath, 0, 1);
-                        if (workspaceChanges != null && workspaceChanges.size() > 0) {
+                        if (workspaceChanges != null && !workspaceChanges.isEmpty()) {
                             newestChange = workspaceChanges.get(0);
                         } else {
                             List<Integer> depotChanges = depot.getChanges().getChangeNumbers("//...", 0, 1);
-                            if (depotChanges != null && depotChanges.size() > 0) {
+                            if (depotChanges != null && !depotChanges.isEmpty()) {
                                 newestChange = depotChanges.get(0);
                             }
                         }
@@ -1072,7 +1072,7 @@ public class PerforceSCM extends SCM {
                 }
                 changes = depot.getChanges().getChangelistsFromNumbers(changeNumbersTo, fileLimit);
 
-                if (changes.size() > 0) {
+                if (!changes.isEmpty()) {
                     // Save the changes we discovered.
                     PerforceChangeLogSet.saveToChangeLog(
                             new FileOutputStream(changelogFile), changes);
@@ -1494,7 +1494,7 @@ public class PerforceSCM extends SCM {
             List<String> files = Arrays.asList(
                     MacroStringHelper.substituteParameters(excludedFiles, this, project, node, null).split("\n"));
             
-            if (files.size() > 0 && changelist.getFiles().size() > 0) {
+            if (!files.isEmpty() && !changelist.getFiles().isEmpty()) {
                 StringBuilder buff = new StringBuilder("Exclude file(s) found:\n");
                 for (FileEntry f : changelist.getFiles()) {
                     if (!doesFilenameMatchAnyP4Pattern(f.getFilename(),files,excludedFilesCaseSensitivity) &&


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
Ayman Abdelghany.