### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/perforce/api/Debug.java
+++ b/src/main/java/com/perforce/api/Debug.java
@@ -72,6 +72,9 @@ public final class Debug {
 
 	private static boolean show_thread = false;
 
+	private Debug() {
+	}
+
 	/**
 	 * Returns the name associated with the specified level.
 	 * 

--- a/src/main/java/com/perforce/api/Utils.java
+++ b/src/main/java/com/perforce/api/Utils.java
@@ -39,6 +39,9 @@ public final class Utils {
 
     private static final String ENCODING_SCHEME = "UTF-8";
 
+	private Utils() {
+	}
+
 	/**
 	 * Initializes the package, in order to avoid some arbitrary JVM problems
 	 * that have been encountered. This is a hack and should not have to be done

--- a/src/main/java/hudson/plugins/perforce/utils/JobSubstitutionHelper.java
+++ b/src/main/java/hudson/plugins/perforce/utils/JobSubstitutionHelper.java
@@ -45,7 +45,10 @@ import javax.annotation.Nonnull;
  * @since 1.3.32
  */
 public class JobSubstitutionHelper {
-    
+
+    private JobSubstitutionHelper() {
+    }
+
     /**package*/ static void getDefaultSubstitutions(
             @Nonnull AbstractProject project, 
             @Nonnull Map<String, String> subst) {

--- a/src/main/java/hudson/plugins/perforce/utils/MacroStringHelper.java
+++ b/src/main/java/hudson/plugins/perforce/utils/MacroStringHelper.java
@@ -52,7 +52,10 @@ import javax.annotation.Nonnull;
 public class MacroStringHelper {
     
     public static final Level SUBSTITUTION_ERROR_LEVEL = Level.WARNING;
-    
+
+    private MacroStringHelper() {
+    }
+
     /**
      * Substitute parameters and validate contents of the resulting string.
      * This is a generic method, which invokes routines for {@link AbstractBuild} if it is not null.

--- a/src/main/java/hudson/plugins/perforce/utils/NodeSubstitutionHelper.java
+++ b/src/main/java/hudson/plugins/perforce/utils/NodeSubstitutionHelper.java
@@ -47,6 +47,9 @@ public class NodeSubstitutionHelper {
 
     private static final Logger LOGGER = Logger.getLogger(PerforceSCM.class.getName());
 
+    private NodeSubstitutionHelper() {
+    }
+
     /**
      * Gets default variable substitutions for the {@link Node}.
      * The method injects global and node-specific {@link EnvironmentVariablesNodeProperty}

--- a/src/test/java/hudson/plugins/perforce/utils/JobSubstitutionHelperTest.java
+++ b/src/test/java/hudson/plugins/perforce/utils/JobSubstitutionHelperTest.java
@@ -42,7 +42,10 @@ import org.jvnet.hudson.test.Bug;
  */
 @Ignore
 public class JobSubstitutionHelperTest {
-      
+
+    private JobSubstitutionHelperTest() {
+    }
+
     public static void assertNoSpecialSymbols(@Nonnull String value) {
         Assert.assertFalse(value.contains("/"));
         Assert.assertFalse(value.contains("="));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.