### PR TITLE
 Parsing should be used to convert "Strings" to primitives

### DIFF
--- a/src/main/java/com/perforce/api/Change.java
+++ b/src/main/java/com/perforce/api/Change.java
@@ -83,7 +83,7 @@ public final class Change extends SourceControlObject {
 
 	public Change(String number) {
 		this();
-		this.number = Integer.valueOf(number).intValue();
+		this.number = Integer.parseInt(number);
 	}
 
 	private static HashDecay setCache() {
@@ -305,7 +305,7 @@ public final class Change extends SourceControlObject {
 						fent.setDepotPath(t.substring(beg, end));
 						beg = end + 1;
 						if(-1 != (end = t.indexOf(' ', beg))) {
-							fent.setHeadRev(Integer.valueOf(t.substring(beg, end).trim()).intValue());
+							fent.setHeadRev(Integer.parseInt(t.substring(beg, end).trim()));
 							fent.setHeadAction(t.substring(end + 1));
 						}
 					} else {
@@ -452,7 +452,7 @@ public final class Change extends SourceControlObject {
 			while(null != (l = p.readLine())) {
 				Debug.notify("READ: " + l);
 				if(l.startsWith("Change ") && (-1 != (pos = l.indexOf("created")))) {
-					setNumber(Integer.valueOf(l.substring(7, pos - 1).trim()).intValue());
+					setNumber(Integer.parseInt(l.substring(7, pos - 1).trim()));
 				}
 				if(l.startsWith("Error"))
 					store_failed = true;

--- a/src/main/java/com/perforce/api/Counter.java
+++ b/src/main/java/com/perforce/api/Counter.java
@@ -130,7 +130,7 @@ public final class Counter extends SourceControlObject {
 			p = new P4Process(getEnv());
 			p.exec(cmd);
 			l = p.readLine();
-			value = Integer.valueOf(l).intValue();
+			value = Integer.parseInt(l);
 			while(null != (l = p.readLine())) {
 			}
 			p.close();

--- a/src/main/java/com/perforce/api/Env.java
+++ b/src/main/java/com/perforce/api/Env.java
@@ -336,7 +336,7 @@ public class Env {
 			setSystemRoot(value);
 		} else if(key.equals("p4.threshold")) {
 			try {
-				setServerTimeout(Integer.valueOf(value).intValue());
+				setServerTimeout(Integer.parseInt(value));
 			} catch(Exception ex) { /* Ignored Exception */
 			}
 		}
@@ -424,7 +424,7 @@ public class Env {
 		setSystemDrive(getProperty("p4.sysdrive", "C:"));
 		setSystemRoot(getProperty("p4.sysroot", "C:\\WINNT"));
 		try {
-			setServerTimeout(Integer.valueOf(getProperty("p4.threshold", "10000")).intValue());
+			setServerTimeout(Integer.parseInt(getProperty("p4.threshold", "10000")));
 		} catch(Exception ex) { /* Ignored Exception */
 		}
 

--- a/src/main/java/com/perforce/api/FileEntry.java
+++ b/src/main/java/com/perforce/api/FileEntry.java
@@ -1200,15 +1200,15 @@ public final class FileEntry extends SourceControlObject {
 			} else if(dataname.equals("headAction")) {
 				nfe.setHeadAction(datavalue);
 			} else if(dataname.equals("headChange")) {
-				nfe.setHeadChange(new Integer(datavalue).intValue());
+				nfe.setHeadChange(Integer.parseInt(datavalue));
 			} else if(dataname.equals("headRev")) {
-				nfe.setHeadRev(new Integer(datavalue).intValue());
+				nfe.setHeadRev(Integer.parseInt(datavalue));
 			} else if(dataname.equals("headType")) {
 				nfe.setHeadType(datavalue);
 			} else if(dataname.equals("headTime")) {
-				nfe.setHeadTime(new Long(datavalue).longValue());
+				nfe.setHeadTime(Long.parseLong(datavalue));
 			} else if(dataname.equals("haveRev")) {
-				nfe.setHaveRev(new Integer(datavalue).intValue());
+				nfe.setHaveRev(Integer.parseInt(datavalue));
 			} else if(dataname.equals("action")) {
 
 			} else if(dataname.equals("change")) {

--- a/src/main/java/com/perforce/api/JobField.java
+++ b/src/main/java/com/perforce/api/JobField.java
@@ -126,10 +126,10 @@ public final class JobField {
 
 		try {
 			st.nextToken(); /* Skip 'info:' */
-			code = Integer.valueOf(st.nextToken()).intValue();
+			code = Integer.parseInt(st.nextToken());
 			name = st.nextToken();
 			dtype = st.nextToken();
-			len = Integer.valueOf(st.nextToken()).intValue();
+			len = Integer.parseInt(st.nextToken());
 			ftype = st.nextToken();
 			jf = new JobField(code, name, dtype, len, ftype);
 		} catch(Exception ex) {

--- a/src/main/java/com/perforce/api/P4Process.java
+++ b/src/main/java/com/perforce/api/P4Process.java
@@ -443,8 +443,7 @@ public class P4Process {
 						} else if(line.startsWith("text")) {
 						} else if(line.startsWith("info")) {
 						} else if(line.startsWith("exit")) {
-							int exit_code = new Integer(line.substring(line.indexOf(" ") + 1, line.length()))
-									.intValue();
+							int exit_code = Integer.parseInt(line.substring(line.indexOf(" ") + 1, line.length()));
 							if(0 == exit_code) {
 								Debug.verbose("P4 Exec Complete.");
 							} else {

--- a/src/main/java/com/perforce/api/Utils.java
+++ b/src/main/java/com/perforce/api/Utils.java
@@ -209,7 +209,7 @@ public final class Utils {
 		if(0 > i)
 			return -1;
 		try {
-			return Integer.valueOf(path.substring(i + 1)).intValue();
+			return Integer.parseInt(path.substring(i + 1));
 		} catch(NumberFormatException ex) {
 			return -1;
 		}

--- a/src/main/java/com/tek42/perforce/parse/ChangelistBuilder.java
+++ b/src/main/java/com/tek42/perforce/parse/ChangelistBuilder.java
@@ -317,8 +317,8 @@ public class ChangelistBuilder implements Builder<Changelist> {
 		GregorianCalendar cal = (GregorianCalendar) Calendar.getInstance();
 		cal.clear();
 
-		cal.set(new Integer(date[0]).intValue(), (new Integer(date[1]).intValue() - 1), new Integer(date[2]).intValue(), new Integer(
-				time[0]).intValue(), new Integer(time[1]).intValue(), new Integer(time[2]).intValue());
+		cal.set(Integer.parseInt(date[0]), (Integer.parseInt(date[1]) - 1), Integer.parseInt(date[2]), Integer.parseInt(
+				time[0]), Integer.parseInt(time[1]), Integer.parseInt(time[2]));
 
 		return cal.getTime();
 	}

--- a/src/main/java/hudson/plugins/perforce/PerforceChangeLogParser.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceChangeLogParser.java
@@ -252,9 +252,9 @@ public class PerforceChangeLogParser extends ChangeLogParser {
         GregorianCalendar cal = (GregorianCalendar) Calendar.getInstance();
         cal.clear();
 
-        cal.set(new Integer(date[0]).intValue(), (new Integer(date[1]).intValue() - 1),
-                new Integer(date[2]).intValue(), new Integer(time[0]).intValue(), new Integer(time[1]).intValue(),
-                new Integer(time[2]).intValue());
+        cal.set(Integer.parseInt(date[0]), (Integer.parseInt(date[1]) - 1),
+                Integer.parseInt(date[2]), Integer.parseInt(time[0]), Integer.parseInt(time[1]),
+                Integer.parseInt(time[2]));
 
         return cal.getTime();
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2130 - “ Parsing should be used to convert "Strings" to primitives”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2130
Please let me know if you have any questions.
Ayman Abdelghany.