### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/src/main/java/com/perforce/api/Branch.java
+++ b/src/main/java/com/perforce/api/Branch.java
@@ -230,7 +230,7 @@ public class Branch extends Mapping {
 	 * @return Change containing the files integrated.
 	 * @see Change
 	 */
-	public static Change integrate(Env env, Vector fents, String branch, StringBuffer sb, String description)
+	public static Change integrate(Env env, Vector fents, String branch, StringBuilder sb, String description)
 			throws CommitException, PerforceException {
 		Change c = new Change();
 		c.setEnv(env);
@@ -259,7 +259,7 @@ public class Branch extends Mapping {
 	 * @return Change containing the files integrated.
 	 * @see Change
 	 */
-	public static Change integrate(Env env, Vector fents, String branch, StringBuffer sb, Change c)
+	public static Change integrate(Env env, Vector fents, String branch, StringBuilder sb, Change c)
 			throws PerforceException {
 		FileEntry fent;
 
@@ -280,9 +280,9 @@ public class Branch extends Mapping {
 	 *            buffer that will contain a log of the integration.
 	 * @param c
 	 *            Change to be used to contain the integrated files.
-	 * @see Branch#integrate(Env,String,String,StringBuffer,Change)
+	 * @see Branch#integrate(Env,String,String,StringBuilder,Change)
 	 */
-	public Change integrate(String source, StringBuffer sb, Change c) throws PerforceException {
+	public Change integrate(String source, StringBuilder sb, Change c) throws PerforceException {
 		if(null == c) {
 			c = new Change();
 			c.setDescription("Automated Integration");
@@ -309,7 +309,7 @@ public class Branch extends Mapping {
 	 * @return Change containing the files integrated.
 	 * @see Change
 	 */
-	public static Change integrate(Env env, String source, String branch, StringBuffer sb, Change c)
+	public static Change integrate(Env env, String source, String branch, StringBuilder sb, Change c)
 			throws PerforceException {
 		String[] intcmd = { "p4", "integrate", "-v", "-d", "-c", String.valueOf(c.getNumber()), "-b", branch, "-s",
 				source };
@@ -425,7 +425,7 @@ public class Branch extends Mapping {
 	}
 
 	public String toXML() {
-		StringBuffer sb = new StringBuffer("<branch name=\"");
+		StringBuilder sb = new StringBuilder("<branch name=\"");
 		sb.append(getName());
 		sb.append("\" owner=\"");
 		sb.append(getOwner());

--- a/src/main/java/com/perforce/api/Change.java
+++ b/src/main/java/com/perforce/api/Change.java
@@ -192,7 +192,7 @@ public final class Change extends SourceControlObject {
 	public void setDescription(String description) {
 		String l;
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			BufferedReader b = new BufferedReader(new StringReader(description));
 			while(null != (l = b.readLine())) {
 				sb.append('\t');
@@ -221,7 +221,7 @@ public final class Change extends SourceControlObject {
 	}
 
 	public String getShortDescription(boolean blurb) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		String l;
 		try {
 			BufferedReader b = new BufferedReader(new StringReader(getDescription()));
@@ -342,7 +342,7 @@ public final class Change extends SourceControlObject {
 	 *            Indicates whether the resolve should be forced.
 	 */
 	public String resolve(boolean force) throws PerforceException {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		Enumeration en = getFileEntries().elements();
 
 		try {
@@ -378,7 +378,7 @@ public final class Change extends SourceControlObject {
 	 */
 	public String submit() throws SubmitException {
 		String l;
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if(PENDING != status) {
 			throw new SubmitException("Change already submitted.");
 		}
@@ -409,7 +409,7 @@ public final class Change extends SourceControlObject {
 	public void commit() throws CommitException {
 		Enumeration en;
 		Vector fents = getFileEntries();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		String[] cmd = { "p4", "change", "-i" };
 		String l;
 		int pos;
@@ -555,7 +555,7 @@ public final class Change extends SourceControlObject {
 	 */
 	public String deleteEmptyChange() throws PerforceException {
 		String l;
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if(PENDING != status) {
 			throw new PerforceException("Change already submitted.");
 		}
@@ -579,7 +579,7 @@ public final class Change extends SourceControlObject {
 	 * Overrides the default toString() method.
 	 */
 	public String toString() {
-		StringBuffer sb = new StringBuffer("Change: ");
+		StringBuilder sb = new StringBuilder("Change: ");
 		sb.append(number);
 		sb.append("\nUser: ");
 		sb.append(user);
@@ -696,7 +696,7 @@ public final class Change extends SourceControlObject {
 	}
 
 	public String toXML() {
-		StringBuffer sb = new StringBuffer("<change number=\"");
+		StringBuilder sb = new StringBuilder("<change number=\"");
 		sb.append(getNumber());
 		sb.append("\" user=\"");
 		sb.append(getUser());

--- a/src/main/java/com/perforce/api/Client.java
+++ b/src/main/java/com/perforce/api/Client.java
@@ -380,7 +380,7 @@ public final class Client extends Mapping {
 	}
 
 	public String toXML() {
-		StringBuffer sb = new StringBuffer("<client name=\"");
+		StringBuilder sb = new StringBuilder("<client name=\"");
 		sb.append(getName());
 		sb.append("\" owner=\"");
 		sb.append(getOwner());

--- a/src/main/java/com/perforce/api/Counter.java
+++ b/src/main/java/com/perforce/api/Counter.java
@@ -244,7 +244,7 @@ public final class Counter extends SourceControlObject {
 	}
 
 	public String toXML() {
-		StringBuffer sb = new StringBuffer("<counter name=\"");
+		StringBuilder sb = new StringBuilder("<counter name=\"");
 		sb.append(this.name);
 		sb.append("\" value=\"");
 		sb.append(this.value);

--- a/src/main/java/com/perforce/api/Debug.java
+++ b/src/main/java/com/perforce/api/Debug.java
@@ -286,7 +286,7 @@ public final class Debug {
 	public static void notify(String msg, String[] arry) {
 		if(NOTICE > level)
 			return;
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for(int i = 0; i < arry.length; i++) {
 			sb.append(arry[i]);
 			sb.append(' ');
@@ -331,7 +331,7 @@ public final class Debug {
 	public static void verbose(String msg, String[] arry) {
 		if(VERBOSE > level)
 			return;
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for(int i = 0; i < arry.length; i++) {
 			sb.append(arry[i]);
 			sb.append(' ');
@@ -430,7 +430,7 @@ public final class Debug {
 	public static void out(int level, String msg, String[] arry) {
 		if(level > Debug.level)
 			return;
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for(int i = 0; i < arry.length; i++) {
 			sb.append(arry[i]);
 			sb.append(' ');

--- a/src/main/java/com/perforce/api/DirEntry.java
+++ b/src/main/java/com/perforce/api/DirEntry.java
@@ -369,7 +369,7 @@ public final class DirEntry extends SourceControlObject {
 	}
 
 	public String toXML() {
-		StringBuffer sb = new StringBuffer("<dir path=\"");
+		StringBuilder sb = new StringBuilder("<dir path=\"");
 		sb.append(getPath());
 		sb.append("\"/>");
 		return sb.toString();

--- a/src/main/java/com/perforce/api/Env.java
+++ b/src/main/java/com/perforce/api/Env.java
@@ -549,7 +549,7 @@ public class Env {
 			return;
 		}
 		StringTokenizer st = new StringTokenizer(orig_path, sep_path);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		while(st.hasMoreTokens()) {
 			tok = (String) st.nextToken();
 			if(tok.equals(path))
@@ -646,7 +646,7 @@ public class Env {
 
 	public String toString() {
 		String[] envp = getEnvp();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for(int i = 0; i < envp.length; i++) {
 			sb.append(envp[i]);
 			sb.append("\n");
@@ -658,7 +658,7 @@ public class Env {
 	 * Returns an XML representation of the environment.
 	 */
 	public String toXML() {
-		StringBuffer sb = new StringBuffer("<env");
+		StringBuilder sb = new StringBuilder("<env");
 		sb.append(" user=\"");
 		sb.append(getUser());
 		sb.append("\" client=\"");

--- a/src/main/java/com/perforce/api/EventLog.java
+++ b/src/main/java/com/perforce/api/EventLog.java
@@ -211,7 +211,7 @@ public class EventLog {
 	 *            Indicates that the output should be XML/HTML encoded.
 	 */
 	public synchronized void log(String event, String level, boolean encode) {
-		StringBuffer sb = new StringBuffer("<log level=\"");
+		StringBuilder sb = new StringBuilder("<log level=\"");
 		if(null == level) {
 			if(-1 == event.indexOf("ERROR")) {
 				sb.append("NOMINAL");

--- a/src/main/java/com/perforce/api/FileEntry.java
+++ b/src/main/java/com/perforce/api/FileEntry.java
@@ -302,7 +302,7 @@ public final class FileEntry extends SourceControlObject {
 	 *            Character to be changed to.
 	 */
 	public static String customizePath(String str, char from_char, char to_char) {
-		StringBuffer strbuf = new StringBuffer();
+		StringBuilder strbuf = new StringBuilder();
 		int beg = 0, end = 0;
 		while(-1 != (end = str.indexOf(from_char, beg))) {
 			strbuf.append(str.substring(beg, end));
@@ -322,7 +322,7 @@ public final class FileEntry extends SourceControlObject {
 	 *            Indicates whether the resolve should be forced.
 	 */
 	public String resolve(boolean force) throws IOException {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		String l;
 		String[] rescmd = { "p4", "resolve", "-am", "fileRev" };
 		if(force || -1 != (getHeadType().indexOf("binary")) || -1 != (getHeadType().indexOf("link"))) {
@@ -353,7 +353,7 @@ public final class FileEntry extends SourceControlObject {
 	 *            <code>Enumeration</code> of <code>FileEntry</code>.
 	 */
 	public static String resolveAT(Env env, Enumeration en) throws IOException {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		FileEntry fent;
 		String l;
 		String[] rescmd = { "p4", "-x", "-", "resolve", "-at" };
@@ -391,7 +391,7 @@ public final class FileEntry extends SourceControlObject {
 	 *            Path over which to resolve. May include wildcards.
 	 */
 	public static String resolveAll(Env env, String flags, String path) throws IOException {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		FileEntry fent;
 		String l;
 		String[] rescmd = { "p4", "resolve", flags, path };
@@ -414,7 +414,7 @@ public final class FileEntry extends SourceControlObject {
 	public static String HTMLEncode(String str) {
 		if(null == str)
 			return null;
-		StringBuffer strbuf = new StringBuffer(str.length());
+		StringBuilder strbuf = new StringBuilder(str.length());
 		char tmp;
 		for(int i = 0; i < str.length(); i++) {
 			tmp = str.charAt(i);
@@ -1115,7 +1115,7 @@ public final class FileEntry extends SourceControlObject {
 	 */
 	public String getFileContents(Env env, String path) {
 		String l;
-		StringBuffer ret = null;
+		StringBuilder ret = null;
 		String[] cmd = { "p4", "print", path };
 		try {
 			P4Process p = new P4Process(env);
@@ -1123,7 +1123,7 @@ public final class FileEntry extends SourceControlObject {
 			p.exec(cmd);
 			while(null != (l = p.readLine())) {
 				if(null == ret) {
-					ret = new StringBuffer();
+					ret = new StringBuilder();
 				} else if(l.startsWith("text: ")) {
 					ret.append(l.substring(6));
 					if(!l.endsWith("\n"))
@@ -1131,7 +1131,7 @@ public final class FileEntry extends SourceControlObject {
 				}
 			}
 			if(null == ret) {
-				ret = new StringBuffer();
+				ret = new StringBuilder();
 			}
 
 			if(0 != p.close()) {
@@ -1231,7 +1231,7 @@ public final class FileEntry extends SourceControlObject {
 	}
 
 	public String toXML() {
-		StringBuffer sb = new StringBuffer("<file><have rev=\"");
+		StringBuilder sb = new StringBuilder("<file><have rev=\"");
 		sb.append(getHaveRev());
 		sb.append("\"/><head rev=\"");
 		sb.append(getHeadRev());

--- a/src/main/java/com/perforce/api/Job.java
+++ b/src/main/java/com/perforce/api/Job.java
@@ -670,7 +670,7 @@ public final class Job extends SourceControlObject {
 	}
 
 	public String toXML() {
-		StringBuffer sb = new StringBuffer("<job name=\"");
+		StringBuilder sb = new StringBuilder("<job name=\"");
 		sb.append(getName());
 		sb.append("\" user=\"");
 		sb.append(getUser());

--- a/src/main/java/com/perforce/api/JobField.java
+++ b/src/main/java/com/perforce/api/JobField.java
@@ -267,7 +267,7 @@ public final class JobField {
 	}
 
 	public String toXML() {
-		StringBuffer sb = new StringBuffer("<field>");
+		StringBuilder sb = new StringBuilder("<field>");
 		sb.append("</field>");
 		return sb.toString();
 	}

--- a/src/main/java/com/perforce/api/Label.java
+++ b/src/main/java/com/perforce/api/Label.java
@@ -315,7 +315,7 @@ public class Label extends Mapping {
 	}
 
 	public String toXML() {
-		StringBuffer sb = new StringBuffer("<label name=\"");
+		StringBuilder sb = new StringBuilder("<label name=\"");
 		sb.append(getName());
 		sb.append("\" owner=\"");
 		sb.append(getOwner());

--- a/src/main/java/com/perforce/api/Mapping.java
+++ b/src/main/java/com/perforce/api/Mapping.java
@@ -149,7 +149,7 @@ public abstract class Mapping extends SourceControlObject implements Comparable 
 	 * @return String version of all the views in this mapping.
 	 */
 	public synchronized String getView() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		Enumeration en = views.keys();
 		String key, val;
 		while(en.hasMoreElements()) {
@@ -214,7 +214,7 @@ public abstract class Mapping extends SourceControlObject implements Comparable 
 	public abstract void sync(String name);
 
 	public String toXML() {
-		StringBuffer sb = new StringBuffer("<mappings>");
+		StringBuilder sb = new StringBuilder("<mappings>");
 		Enumeration en = views.keys();
 		String key, val;
 		while(en.hasMoreElements()) {

--- a/src/main/java/com/perforce/api/User.java
+++ b/src/main/java/com/perforce/api/User.java
@@ -306,7 +306,7 @@ public final class User extends SourceControlObject {
 	}
 
 	public String toXML() {
-		StringBuffer sb = new StringBuffer("<user id=\"");
+		StringBuilder sb = new StringBuilder("<user id=\"");
 		sb.append(getId());
 		sb.append("\" fullname=\"");
 		sb.append(getFullName());

--- a/src/main/java/com/perforce/api/Utils.java
+++ b/src/main/java/com/perforce/api/Utils.java
@@ -141,7 +141,7 @@ public final class Utils {
 	public static String HTMLEncode(String str) {
 		if(null == str)
 			return "null";
-		StringBuffer strbuf = new StringBuffer(str.length());
+		StringBuilder strbuf = new StringBuilder(str.length());
 		char tmp;
 		for(int i = 0; i < str.length(); i++) {
 			tmp = str.charAt(i);

--- a/src/main/java/com/tek42/perforce/Depot.java
+++ b/src/main/java/com/tek42/perforce/Depot.java
@@ -428,7 +428,7 @@ public class Depot {
 			return;
 		}
 		StringTokenizer st = new StringTokenizer(origPath, pathSep);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		while(st.hasMoreTokens()) {
 			tok = st.nextToken();
 			if(tok.equals(path))

--- a/src/main/java/hudson/plugins/perforce/PerforceChangeLogParser.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceChangeLogParser.java
@@ -34,7 +34,7 @@ public class PerforceChangeLogParser extends ChangeLogParser {
     
     public static class ChangeLogHandler extends DefaultHandler {
         private Stack objects = new Stack();
-        private StringBuffer text = new StringBuffer();
+        private StringBuilder text = new StringBuilder();
 
         private List<PerforceChangeLogEntry> changeLogEntries = null;
         private PerforceChangeLogSet changeLogSet = null;

--- a/src/main/java/hudson/plugins/perforce/PerforcePasswordEncryptor.java
+++ b/src/main/java/hudson/plugins/perforce/PerforcePasswordEncryptor.java
@@ -119,7 +119,7 @@ public class PerforcePasswordEncryptor {
     private static String convertBytesToString(byte[] bytes) {
         if (bytes == null)
             return "";
-        StringBuffer stringBuffer = new StringBuffer(bytes.length);
+        StringBuilder stringBuffer = new StringBuilder(bytes.length);
         for (int i = 0; i < bytes.length; i++) {
             stringBuffer.append((char) bytes[i]);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.