### PR TITLE
nested variables were not properly replaced

### DIFF
--- a/src/main/java/hudson/plugins/perforce/PerforceSCM.java
+++ b/src/main/java/hudson/plugins/perforce/PerforceSCM.java
@@ -103,7 +103,7 @@ public class PerforceSCM extends SCM {
 
     private static final String WORKSPACE_COMBINATOR = System.getProperty(hudson.slaves.WorkspaceList.class.getName(),"@");
 
-    private static final int MAX_BUILD_ENV_VARS_NESTED_CALLS = 2;
+    private static final int MAX_BUILD_ENV_VARS_NESTED_CALLS = 4;
     
     /**
      * Name of the p4 tool installation

--- a/src/main/java/hudson/plugins/perforce/utils/MacroStringHelper.java
+++ b/src/main/java/hudson/plugins/perforce/utils/MacroStringHelper.java
@@ -243,7 +243,13 @@ public class MacroStringHelper {
             JobSubstitutionHelper.getDefaultSubstitutions(project, substitutions);
         }
         getDefaultSubstitutions(instance, substitutions);
-        outputString = substituteParametersNoCheck(outputString, substitutions);    
+        int count = 0;
+        
+        do{
+        	 outputString = substituteParametersNoCheck(outputString, substitutions);  
+        	 count++;
+        }while(count<4 && containsMacro(outputString));
+           
         
         return outputString;
     }


### PR DESCRIPTION
I had an inherited parameter ${PARAM} in jenkins used in perforce workspace defined as
${PARAM}=${PARAM1}\${PARAM2}
While performing the Perforce polling, a substitution of the variables/parameters by the value occurs, but we got in our case a fatal error ( see below)
we noticed that the variable ${PARAM} had been only partially replaced by ${PARAM1}\XXXXX
we also noticed that sometimes the nested replacement worked.
it was due how the variables were ordered into "substitutions" HashMap in MacroStringHelper.java.
we decided to loop through 
outputString = substituteParametersNoCheck(outputString, substitutions);  and it worked. all the macros were replaced.


FATAL ERROR that was discovered while doing Perforce polling in jenkins:
at hudson.plugins.perforce.utils.MacroStringHelper.checkString(MacroStringHelper.java:154)
at hudson.plugins.perforce.utils.MacroStringHelper.substituteParameters(MacroStringHelper.java:102)
at hudson.plugins.perforce.utils.MacroStringHelper.substituteParameters(MacroStringHelper.java:78)
at hudson.plugins.perforce.PerforceSCM.getEffectiveProjectPath(PerforceSCM.java:701)
at hudson.plugins.perforce.PerforceSCM.compareRemoteRevisionWith(PerforceSCM.java:1314)
at hudson.scm.SCM.poll(SCM.java:408)
at hudson.model.AbstractProject._poll(AbstractProject.java:1460)
at hudson.model.AbstractProject.poll(AbstractProject.java:1363)
at hudson.triggers.SCMTrigger$Runner.runPolling(SCMTrigger.java:563)
at hudson.triggers.SCMTrigger$Runner.run(SCMTrigger.java:609)
at hudson.util.SequentialExecutionQueue$QueueEntry.run(SequentialExecutionQueue.java:119)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
at java.lang.Thread.run(Thread.java:745)