### PR TITLE
Explicitly indicate that @oleg-nenashev does not maintain the plugin anymore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,9 @@
     <developer>
       <id>oleg_nenashev</id>
       <name>Oleg Nenashev</name>
+      <roles>
+        <role>Maintainer (retired)</role>
+      </roles>
       <email>o dot v dot nenashev at gmail dot com</email>
     </developer>
   </developers>


### PR DESCRIPTION
I still get private emails about the plugin sometimes. I have not been using Perforce for more than 3 years && I have no environment for testing changes even if I want to resolve something. So I would like to make my role explicit.

@rpetti I'd guess it's pretty same for you. Maybe we could just mark the plugin for adoption and move on? There is a deprecation notice in public, so it seems to be reasonable. Unfortunately, P4 plugin still does not replace all available functionality.

@rpetti @reviewbybees 
